### PR TITLE
Include the WooCommerce git hooks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
     "wimg/php-compatibility": "^8.1",
     "woocommerce/woocommerce": "dev-feature/more-order-tests",
+    "woocommerce/woocommerce-git-hooks": "*",
     "woocommerce/woocommerce-sniffs": "^0.0.1",
     "wp-coding-standards/wpcs": "^0.14"
   },
@@ -35,6 +36,18 @@
     ]
   },
   "scripts": {
+    "pre-update-cmd": [
+      "WooCommerce\\GitHooks\\Hooks::preHooks"
+    ],
+    "pre-install-cmd": [
+      "WooCommerce\\GitHooks\\Hooks::preHooks"
+    ],
+    "post-install-cmd": [
+      "WooCommerce\\GitHooks\\Hooks::postHooks"
+    ],
+    "post-update-cmd": [
+      "WooCommerce\\GitHooks\\Hooks::postHooks"
+    ],
     "test-coverage": [
       "phpunit --testsuite=plugin --coverage-html=tests/coverage"
     ]

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "57b6c3231f4d1bbfd878c50a778f2880",
+    "content-hash": "f3c419402a15213ebde4f211fdae66e5",
     "packages": [],
     "packages-dev": [
         {
@@ -365,6 +365,39 @@
                 "source": "https://github.com/liquidweb/woocommerce/tree/feature/more-order-tests"
             },
             "time": "2018-01-18T17:01:18+00:00"
+        },
+        {
+            "name": "woocommerce/woocommerce-git-hooks",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/woocommerce/woocommerce-git-hooks.git",
+                "reference": "1e55118258e8487c68b17c06cfde3b48a692d9d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-git-hooks/zipball/1e55118258e8487c68b17c06cfde3b48a692d9d4",
+                "reference": "1e55118258e8487c68b17c06cfde3b48a692d9d4",
+                "shasum": ""
+            },
+            "type": "scripts",
+            "autoload": {
+                "psr-4": {
+                    "WooCommerce\\GitHooks\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Claudio Sanches",
+                    "email": "claudio@automattic.com"
+                }
+            ],
+            "description": "WooCommerce Git Hooks",
+            "time": "2017-12-18T16:55:42+00:00"
         },
         {
             "name": "woocommerce/woocommerce-sniffs",


### PR DESCRIPTION
The WooCommerce plugin ships with woocommerce/woocommerce-git-hooks that automatically install coding standards-related pre-commit hooks. Since we're 100% compliant at this point, this helps ensure we stay that way.