### PR TITLE
Code coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - php: 7.2
       env: WP_VERSION=trunk WP_MULTISITE=1 WC_VERSION=latest
     - php: 7.1
-      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=latest
+      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=latest RUN_CODE_COVERAGE=1
     - php: 7.1
       env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.2.6
     - php: 7.0
@@ -40,7 +40,14 @@ matrix:
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
-  - phpenv config-rm xdebug.ini
+  - |
+    if [[ ${RUN_CODE_COVERAGE} ]]; then
+      wget https://github.com/php-coveralls/php-coveralls/releases/download/v1.0.0/coveralls.phar
+      chmod +x coveralls.phar
+      mkdir -p build/logs
+    else
+      phpenv config-rm xdebug.ini
+    fi
   - |
     if [[ ${GITHUB_AUTH_TOKEN} != '' ]]; then
       composer config -g github-oauth.github.com $GITHUB_AUTH_TOKEN
@@ -50,8 +57,19 @@ before_script:
   - composer install --prefer-source
 
 script:
-  - phpunit
+  - |
+    if [[ ${RUN_CODE_COVERAGE} ]]; then
+      phpunit --coverage-clover build/logs/clover.xml
+    else
+      phpunit
+    fi
   - |
     if [[ ${RUN_PHPCS} == 1 ]]; then
       ./vendor/bin/phpcs
+    fi
+
+after_success:
+  - |
+    if [[ ${RUN_CODE_COVERAGE} ]]; then
+      travis_retry php coveralls.phar
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ matrix:
     - php: 7.2
       env: WP_VERSION=trunk WP_MULTISITE=1 WC_VERSION=latest
     - php: 7.1
+      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=latest
+    - php: 7.1
       env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=latest RUN_CODE_COVERAGE=1
     - php: 7.1
       env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.2.6
@@ -36,6 +38,8 @@ matrix:
       env: WP_VERSION=trunk WP_MULTISITE=1 WC_VERSION=latest
     - php: 7.1
       env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.2.6
+    - php: 7.1
+      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=latest RUN_CODE_COVERAGE=1
 
 
 before_script:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,8 @@ When submitting pull requests, please include relevant tests for your new featur
 
 #### Test coverage
 
+[![Coverage Status](https://coveralls.io/repos/github/liquidweb/woocommerce-custom-orders-table/badge.svg?branch=feature%2Fcode-coverage)](https://coveralls.io/github/liquidweb/woocommerce-custom-orders-table?branch=feature%2Fcode-coverage)
+
 To generate a code coverage report (test coverage percentage as well as areas of untested or under-tested code that could pose risk), you run the following:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # WooCommerce Custom Orders Table
 
 [![Build Status](https://travis-ci.org/liquidweb/woocommerce-custom-orders-table.svg?branch=develop)](https://travis-ci.org/liquidweb/woocommerce-custom-orders-table)
+[![Coverage Status](https://coveralls.io/repos/github/liquidweb/woocommerce-custom-orders-table/badge.svg?branch=feature%2Fcode-coverage)](https://coveralls.io/github/liquidweb/woocommerce-custom-orders-table?branch=feature%2Fcode-coverage)
 
 This plugin improves WooCommerce performance by introducing a custom table to hold all of the most common order information in a single, properly-indexed location.
 


### PR DESCRIPTION
This PR introduces [code coverage reporting through Coveralls](https://coveralls.io/github/liquidweb/woocommerce-custom-orders-table).

The test that runs code coverage is configured not to block Travis pass/fail determinations, [based on Travis' fast_finish directive](https://docs.travis-ci.com/user/customizing-the-build/#Fast-Finishing).

Current code coverage is about 97% 😄 

[![Coverage Status](https://coveralls.io/repos/github/liquidweb/woocommerce-custom-orders-table/badge.svg?branch=feature%2Fcode-coverage)](https://coveralls.io/github/liquidweb/woocommerce-custom-orders-table?branch=feature%2Fcode-coverage)