### PR TITLE
Adjust Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,25 @@ cache:
 
 matrix:
   fast_finish: true
-  php:
-    - 7.2
-    - 7.1
-    - 7.0
-  env:
-    - WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=latest
-    - WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.3.3
-    - WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.2.6
   include:
+    - php: 7.2
+      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=latest
+    - php: 7.1
+      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=latest
+    - php: 7.0
+      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=latest
+    - php: 7.2
+      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.3.3
+    - php: 7.1
+      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.3.3
+    - php: 7.0
+      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.3.3
+    - php: 7.2
+      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.2.6
+    - php: 7.1
+      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.2.6
+    - php: 7.0
+      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.2.6
     # Run PHP_CodeSniffer on a bleeding-edge configuration.
     - php: 7.2
       env: WP_VERSION=trunk WP_MULTISITE=0 WC_VERSION=latest RUN_PHPCS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,19 +11,24 @@ cache:
 
 matrix:
   fast_finish: true
+  php:
+    - 7.2
+    - 7.1
+    - 7.0
+  env:
+    - WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=latest
+    - WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.3.3
+    - WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.2.6
   include:
+    # Run PHP_CodeSniffer on a bleeding-edge configuration.
     - php: 7.2
       env: WP_VERSION=trunk WP_MULTISITE=0 WC_VERSION=latest RUN_PHPCS=1
+    # WordPress Multisite on the latest
     - php: 7.2
       env: WP_VERSION=trunk WP_MULTISITE=1 WC_VERSION=latest
-    - php: 7.1
-      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=latest
+    # Generate code coverage from PHP 7.1.
     - php: 7.1
       env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=latest RUN_CODE_COVERAGE=1
-    - php: 7.1
-      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.2.6
-    - php: 7.0
-      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=latest
 
   # The following WooCommerce core test currently fails in multisite, with or without this
   # plugin being active:


### PR DESCRIPTION
This PR adjusts the Travis CI build matrix to run the latest point release for each minor WooCommerce release >= 3.2 (plus master) on PHP 7.0 and higher. Additionally, PHP_CodeSniffer and Multisite tests are run against the "bleeding-edge" (PHP 7.2 + WooCommerce master), while code coverage is built against 7.1/master.

Also, it's worth mentioning that currently all builds running against master are failing, due to a bug in WooCommerce's master branch. [I've done some basic triage and reported it](https://github.com/woocommerce/woocommerce/pull/19436#issuecomment-374221195), but for now please don't let a failure on `WC_Tests_Product_Data_Store::test_search_products()` be considered grounds for not merging PRs.

WooCommerce master: [![Build status for WooCommerce](https://travis-ci.org/woocommerce/woocommerce.svg?branch=master)](https://travis-ci.org/woocommerce/woocommerce)