### PR TITLE
Add tests to attempt to reproduce duplicate ID issues

### DIFF
--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -112,6 +112,22 @@ class CLITest extends TestCase {
 		);
 	}
 
+	public function test_migrate_with_duplicate_ids() {
+		$this->toggle_use_custom_table( false );
+		$order_id = WC_Helper_Order::create_order()->get_id();
+		$this->toggle_use_custom_table( true );
+
+		// Implicitly migrate the data.
+		$order = wc_get_order( $order_id );
+		$order->get_total();
+
+		$this->assertEquals( 1, $this->count_orders_in_table_with_ids( $order_id ));
+
+		$this->cli->migrate();
+
+		$this->assertEquals( 1, $this->count_orders_in_table_with_ids( $order_id ));
+	}
+
 	public function test_backfill() {
 		$order_ids = $this->generate_orders( 5 );
 		$index     = 0;

--- a/tests/test-data-store.php
+++ b/tests/test-data-store.php
@@ -31,6 +31,35 @@ class DataStoreTest extends TestCase {
 		$this->assertEquals( 1, did_action( 'wp_insert_post' ), 'Expected the "wp_insert_post" action to have been fired.' );
 	}
 
+	public function test_loading_a_product_can_automatically_populate_from_meta() {
+		$this->toggle_use_custom_table( false );
+		$order_id = WC_Helper_Order::create_order()->get_id();
+		$this->toggle_use_custom_table( true );
+
+		$this->assertEquals( 0, $this->count_orders_in_table_with_ids( $order_id ) );
+
+		$order = wc_get_order( $order_id );
+
+		$this->assertEquals( 1, $this->count_orders_in_table_with_ids( $order->get_id() ) );
+	}
+
+	/**
+	 * Same as test_loading_a_product_can_automatically_populate_from_meta(), but with the
+	 * auto-migration disabled via the 'wc_custom_order_table_automatic_migration' filter.
+	 */
+	public function test_wc_custom_order_table_automatic_migration_filter() {
+		$this->toggle_use_custom_table( false );
+		$order_id = WC_Helper_Order::create_order()->get_id();
+		$this->toggle_use_custom_table( true );
+
+		add_filter( 'wc_custom_order_table_automatic_migration', '__return_false' );
+
+		$order = wc_get_order( $order_id );
+
+		$this->assertEmpty( $order->get_total() );
+		$this->assertEquals( 0, $this->count_orders_in_table_with_ids( $order_id ) );
+	}
+
 	public function test_delete() {
 		$instance = new WC_Order_Data_Store_Custom_Table();
 		$order    = WC_Helper_Order::create_order();


### PR DESCRIPTION
This PR adds some new tests, designed to _try_ to reproduce the duplicate ID errors reported in #49.

Unfortunately, I haven't been able to reproduce these (programmatically as tests nor through manually running the command), so I'm curious what other factors might be in play (or if the issue has already been fixed since the beta3 release).