### PR TITLE
Refactor test suite

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,18 +3,12 @@
   "description": "Store WooCommerce order data in a custom table for improved performance",
   "type": "wordpress-plugin",
   "license": "GPL-2.0-only",
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/liquidweb/woocommerce"
-    }
-  ],
   "require-dev": {
     "php": "^7.0",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
     "phpunit/phpunit": "6.2.3",
     "wimg/php-compatibility": "^8.1",
-    "woocommerce/woocommerce": "dev-feature/more-order-tests",
+    "woocommerce/woocommerce": "dev-master",
     "woocommerce/woocommerce-git-hooks": "*",
     "woocommerce/woocommerce-sniffs": "^0.0.1",
     "wp-coding-standards/wpcs": "^0.14"

--- a/composer.lock
+++ b/composer.lock
@@ -1761,12 +1761,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce.git",
-                "reference": "8a60d0aee95d09de98eaf202f6881d7930a40a2a"
+                "reference": "5258e00bad59ca4e1c6b836ae693b945b57a7cef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce/zipball/8a60d0aee95d09de98eaf202f6881d7930a40a2a",
-                "reference": "8a60d0aee95d09de98eaf202f6881d7930a40a2a",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce/zipball/5258e00bad59ca4e1c6b836ae693b945b57a7cef",
+                "reference": "5258e00bad59ca4e1c6b836ae693b945b57a7cef",
                 "shasum": ""
             },
             "require": {
@@ -1775,6 +1775,7 @@
             "require-dev": {
                 "apigen/apigen": "^4",
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3",
+                "johnkary/phpunit-speedtrap": "v2.0.0",
                 "nette/utils": "~2.3.0",
                 "phpunit/phpunit": "6.*",
                 "squizlabs/php_codesniffer": "*",
@@ -1797,7 +1798,7 @@
             ],
             "description": "An eCommerce toolkit that helps you sell anything. Beautifully.",
             "homepage": "https://woocommerce.com/",
-            "time": "2018-05-08T15:57:02+00:00"
+            "time": "2018-05-11T15:35:32+00:00"
         },
         {
             "name": "woocommerce/woocommerce-git-hooks",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "298248e6fe3e22300bbedb5e4229e3bd",
+    "content-hash": "17d7b547cf0e4dc5b030877ca4a1850d",
     "packages": [],
     "packages-dev": [
         {
@@ -550,23 +550,23 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.5",
+            "version": "1.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401"
+                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/dfd6be44111a7c41c2e884a336cc4f461b3b2401",
-                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
+                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
-                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/comparator": "^1.1|^2.0|^3.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
@@ -609,20 +609,20 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-02-19T10:16:54+00:00"
+            "time": "2018-04-18T13:57:24+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.3.0",
+            "version": "5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1"
+                "reference": "c89677919c5dd6d3b3852f230a663118762218ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/661f34d0bd3f1a7225ef491a70a020ad23a057a1",
-                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c89677919c5dd6d3b3852f230a663118762218ac",
+                "reference": "c89677919c5dd6d3b3852f230a663118762218ac",
                 "shasum": ""
             },
             "require": {
@@ -672,7 +672,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-12-06T09:29:45+00:00"
+            "time": "2018-04-06T15:36:58+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1564,16 +1564,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.2.2",
+            "version": "3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "d7c00c3000ac0ce79c96fcbfef86b49a71158cd1"
+                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d7c00c3000ac0ce79c96fcbfef86b49a71158cd1",
-                "reference": "d7c00c3000ac0ce79c96fcbfef86b49a71158cd1",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4842476c434e375f9d3182ff7b89059583aa8b27",
+                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27",
                 "shasum": ""
             },
             "require": {
@@ -1583,7 +1583,7 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
                 "bin/phpcs",
@@ -1611,7 +1611,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-12-19T21:44:46+00:00"
+            "time": "2018-02-20T21:35:23+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -1757,16 +1757,16 @@
         },
         {
             "name": "woocommerce/woocommerce",
-            "version": "dev-feature/more-order-tests",
+            "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/liquidweb/woocommerce.git",
-                "reference": "8415cec71cd5fff169dd6af87336247f7f57531b"
+                "url": "https://github.com/woocommerce/woocommerce.git",
+                "reference": "8a60d0aee95d09de98eaf202f6881d7930a40a2a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liquidweb/woocommerce/zipball/8415cec71cd5fff169dd6af87336247f7f57531b",
-                "reference": "8415cec71cd5fff169dd6af87336247f7f57531b",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce/zipball/8a60d0aee95d09de98eaf202f6881d7930a40a2a",
+                "reference": "8a60d0aee95d09de98eaf202f6881d7930a40a2a",
                 "shasum": ""
             },
             "require": {
@@ -1776,8 +1776,7 @@
                 "apigen/apigen": "^4",
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3",
                 "nette/utils": "~2.3.0",
-                "php": ">= 7.0",
-                "phpunit/phpunit": "6.2.3",
+                "phpunit/phpunit": "6.*",
                 "squizlabs/php_codesniffer": "*",
                 "wimg/php-compatibility": "^8.0",
                 "woocommerce/woocommerce-git-hooks": "*",
@@ -1792,38 +1791,13 @@
                     "phpcbf": "Fix coding standards warnings/errors automatically with PHP Code Beautifier"
                 }
             },
-            "scripts": {
-                "pre-update-cmd": [
-                    "WooCommerce\\GitHooks\\Hooks::preHooks"
-                ],
-                "pre-install-cmd": [
-                    "WooCommerce\\GitHooks\\Hooks::preHooks"
-                ],
-                "post-install-cmd": [
-                    "WooCommerce\\GitHooks\\Hooks::postHooks"
-                ],
-                "post-update-cmd": [
-                    "WooCommerce\\GitHooks\\Hooks::postHooks"
-                ],
-                "test": [
-                    "phpunit"
-                ],
-                "phpcs": [
-                    "phpcs -s -p"
-                ],
-                "phpcbf": [
-                    "phpcbf -p"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-3.0-or-later"
             ],
             "description": "An eCommerce toolkit that helps you sell anything. Beautifully.",
             "homepage": "https://woocommerce.com/",
-            "support": {
-                "source": "https://github.com/liquidweb/woocommerce/tree/feature/more-order-tests"
-            },
-            "time": "2018-02-15T23:09:30+00:00"
+            "time": "2018-05-08T15:57:02+00:00"
         },
         {
             "name": "woocommerce/woocommerce-git-hooks",

--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -525,10 +525,10 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 							'key'      => $column,
 							'_old_key' => $meta_query['key'],
 						) );
+					} else {
+						// Let this meta query pass through unaltered.
+						$query_args['_wc_has_meta_columns'] = true;
 					}
-				} else {
-					// Let this meta query pass through unaltered.
-					$query_args['_wc_has_meta_columns'] = true;
 				}
 			}
 		}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -16,32 +16,19 @@ $_bootstrap = dirname( __DIR__ ) . '/vendor/woocommerce/woocommerce/tests/bootst
 if ( ! file_exists( $_bootstrap ) ) {
 	echo "\033[0;31mUnable to find the WooCommerce test bootstrap file. Have you run `composer install`?\033[0;m" . PHP_EOL;
 	exit( 1 );
-
-} elseif ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
-	echo "\033[0;31mCould not find $_tests_dir/includes/functions.php, have you run `tests/bin/install-wp-tests.sh`?\033[0;m" . PHP_EOL;
-	exit( 1 );
 }
-
-// Gives access to tests_add_filter() function.
-require_once $_tests_dir . '/includes/functions.php';
-
-// Manually load the plugin on muplugins_loaded.
-function _manually_load_plugin() {
-	require dirname( dirname( __FILE__ ) ) . '/woocommerce-custom-orders-table.php';
-
-	echo esc_html( sprintf(
-		/* Translators: %1$s is the WooCommerce release being loaded. */
-		__( 'Using WooCommerce %1$s.', 'woocommerce-custom-orders-table' ),
-		WC_VERSION
-	) ) . PHP_EOL;
-
-	WooCommerce_Custom_Orders_Table_Install::activate();
-
-	add_filter( 'woocommerce_email_actions', '__return_empty_array' );
-}
-tests_add_filter( 'muplugins_loaded', '_manually_load_plugin', 11 );
 
 // Finally, Start up the WP testing environment.
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 require_once $_bootstrap;
 require_once __DIR__ . '/testcase.php';
+require_once dirname( __DIR__ ) . '/woocommerce-custom-orders-table.php';
+
+echo esc_html( sprintf(
+	/* Translators: %1$s is the WooCommerce release being loaded. */
+	__( 'Using WooCommerce %1$s.', 'woocommerce-custom-orders-table' ),
+	WC_VERSION
+) ) . PHP_EOL;
+
+// Activate the plugin *after* WooCommerce has been bootstrapped.
+WooCommerce_Custom_Orders_Table_Install::activate();

--- a/tests/test-data-store.php
+++ b/tests/test-data-store.php
@@ -317,6 +317,53 @@ class DataStoreTest extends TestCase {
 		);
 	}
 
+	public function test_filter_database_queries() {
+		$args = [
+			'meta_query' => [
+				'relation' => 'OR',
+				'customer_emails' => [
+					'key'     => '_billing_email',
+					'value'   => [ 'test@example.com' ],
+					'compare' => 'IN',
+				],
+				'customer_ids' => [
+					'key'     => '_customer_user',
+					'value'   => [ 2 ],
+					'compare' => 'IN',
+				],
+			],
+		];
+
+		$this->assertEquals( [
+			'meta_query' => $args['meta_query'],
+			'_wc_has_meta_columns' => false,
+			'wc_order_meta_query'  => [
+				[
+					'key'      => 'billing_email',
+					'value'    => [ 'test@example.com' ],
+					'compare'  => 'IN',
+					'_old_key' => '_billing_email',
+				],
+				[
+					'key'      => 'customer_id',
+					'value'    => [ 2 ],
+					'compare'  => 'IN',
+					'_old_key' => '_customer_user',
+				],
+			],
+		], WC_Order_Data_Store_Custom_Table::filter_database_queries( $args, [] ) );
+	}
+
+	public function test_filter_database_queries_without_meta_queries() {
+		$this->assertEquals( [
+			'foo'                  => 'bar',
+			'wc_order_meta_query'  => [],
+			'_wc_has_meta_columns' => false,
+		], WC_Order_Data_Store_Custom_Table::filter_database_queries( [
+			'foo' => 'bar',
+		], [] ) );
+	}
+
 	/**
 	 * To ensure the regular expressions are working as expected, grab some actual queries from
 	 * WC_Admin_Report::get_order_report_data() and verify.

--- a/tests/test-installation.php
+++ b/tests/test-installation.php
@@ -90,7 +90,10 @@ class InstallationTest extends TestCase {
 	/**
 	 * Test that the generated database schema contains the expected indexes.
 	 *
-	 * @dataProvider table_index_provider()
+	 * @testWith [0, "PRIMARY", "order_id"]
+	 *           [0, "order_key", "order_key"]
+	 *           [1, "customer_id", "customer_id"]
+	 *           [1, "order_total", "total"]
 	 */
 	public function test_database_indexes( $non_unique, $key_name, $column_name ) {
 		global $wpdb;
@@ -115,7 +118,7 @@ class InstallationTest extends TestCase {
 				$non_unique,
 				$index['Non_unique'],
 				sprintf(
-					'Did not match expected non-uniqueness (Received %d, expected %d',
+					'Did not match expected non-uniqueness (Received %d, expected %d)',
 					$non_unique,
 					$index['Non_unique']
 				)
@@ -132,15 +135,6 @@ class InstallationTest extends TestCase {
 		}
 
 		$this->fail( sprintf( 'Could not find an index with name "%s".', $key_name ) );
-	}
-
-	public function table_index_provider() {
-		return array(
-			'Primary key' => array( 0, 'PRIMARY', 'order_id' ),
-			'Order key'   => array( 0, 'order_key', 'order_key' ),
-			'Customer ID' => array( 1, 'customer_id', 'customer_id' ),
-			'Order total' => array( 1, 'order_total', 'total' ),
-		);
 	}
 
 	/**

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -124,7 +124,7 @@ class TestCase extends WC_Unit_Test_Case {
 	 * Emulate deactivating, then subsequently reactivating the plugin.
 	 */
 	protected static function reactivate_plugin() {
-		$plugin = plugin_basename( dirname( __DIR__ ) . '/woocommerce-custom-orders-table.php' );
+		$plugin = basename( dirname( __DIR__ ) ) . '/woocommerce-custom-orders-table.php';
 
 		do_action( 'deactivate_' . $plugin, false );
 		do_action( 'activate_' . $plugin, false );

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -71,7 +71,7 @@ class TestCase extends WC_Unit_Test_Case {
 
 		return (int) $wpdb->get_var( $wpdb->prepare(
 			'SELECT COUNT(order_id) FROM ' . esc_sql( wc_custom_order_table()->get_table_name() ) . '
-			WHERE order_id IN (' . implode( ', ', array_fill( 0, count( $order_ids ), '%d' ) ) . ')',
+			WHERE order_id IN (' . implode( ', ', array_fill( 0, count( (array) $order_ids ), '%d' ) ) . ')',
 		$order_ids ) );
 	}
 

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -94,33 +94,6 @@ class TestCase extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Determine if the custom orders table exists.
-	 *
-	 * @global $wpdb
-	 */
-	protected static function orders_table_exists() {
-		global $wpdb;
-
-		return (bool) $wpdb->get_var( $wpdb->prepare(
-			'SELECT COUNT(*) FROM information_schema.tables WHERE table_name = %s LIMIT 1',
-			wc_custom_order_table()->get_table_name()
-		) );
-	}
-
-	/**
-	 * Drop the wp_woocommerce_orders table.
-	 *
-	 * @global $wpdb
-	 */
-	protected static function drop_orders_table() {
-		global $wpdb;
-
-		$wpdb->query( 'DROP TABLE IF EXISTS ' . esc_sql( wc_custom_order_table()->get_table_name() ) );
-
-		delete_option( WooCommerce_Custom_Orders_Table_Install::SCHEMA_VERSION_KEY );
-	}
-
-	/**
 	 * Emulate deactivating, then subsequently reactivating the plugin.
 	 */
 	protected static function reactivate_plugin() {


### PR DESCRIPTION
This PR aims to solve a few issues that have come up in testing, with the hopes of making the test suite less fragile as WooCommerce evolves:

## 1. Return to using the official WooCommerce upstream

[A number of our PRs have been merged into WooCommerce core](https://github.com/woocommerce/woocommerce/pulls?utf8=%E2%9C%93&q=is%3Apr+author%3Astevegrunwell), so there's no longer a need for our temporary `feature/more-orders-tests` branch.

## 2. Simplify the bootstrap file

Since the Custom Orders Table plugin relies on WooCommerce, let the WooCommerce core test suite bootstrap everything before we activate. This prevents incidents where, for example, a test run in isolation did not have access to the custom table.

## 3. Fix an improperly-nested else statement in WC_Order_Data_Store_Custom_Table::filter_database_queries()

This `else` statement was one level too high, causing issues when order queries were constructed with both `customer_emails` and `customer_ids` meta queries. Additional tests have been added around the method to prevent regressions.

## 4. Bump all Composer dependencies

We're only as good as the latest version of WooCommerce we're testing against.

**Please note** that there is one failing test, which is to be expected; the results of `WC_Install::get_tables()` are not sorted, so the order of the tables comes out jumbled:

```
1) WC_Tests_Install::test_get_tables
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
-    8 => 'wptests_woocommerce_orders'
-    9 => 'wptests_woocommerce_payment_tokenmeta'
-    10 => 'wptests_woocommerce_payment_tokens'
-    11 => 'wptests_woocommerce_sessions'
-    12 => 'wptests_woocommerce_shipping_zone_locations'
-    13 => 'wptests_woocommerce_shipping_zone_methods'
-    14 => 'wptests_woocommerce_shipping_zones'
-    15 => 'wptests_woocommerce_tax_rate_locations'
-    16 => 'wptests_woocommerce_tax_rates'
+    8 => 'wptests_woocommerce_payment_tokenmeta'
+    9 => 'wptests_woocommerce_payment_tokens'
+    10 => 'wptests_woocommerce_sessions'
+    11 => 'wptests_woocommerce_shipping_zone_locations'
+    12 => 'wptests_woocommerce_shipping_zone_methods'
+    13 => 'wptests_woocommerce_shipping_zones'
+    14 => 'wptests_woocommerce_tax_rate_locations'
+    15 => 'wptests_woocommerce_tax_rates'
+    16 => 'wptests_woocommerce_orders'
```

I'm working on fixing this within WooCommerce core in woocommerce/woocommerce#20045.