### PR TITLE
Handle exceptions during migration

### DIFF
--- a/includes/class-woocommerce-custom-orders-table-cli.php
+++ b/includes/class-woocommerce-custom-orders-table-cli.php
@@ -73,7 +73,7 @@ class WooCommerce_Custom_Orders_Table_CLI extends WP_CLI_Command {
 	public function migrate( $args = array(), $assoc_args = array() ) {
 		global $wpdb;
 
-		add_action( 'woocommerce_caught_exception', array( $this, 'handle_exceptions' ) );
+		add_action( 'woocommerce_caught_exception', 'self::handle_exceptions' );
 
 		$wpdb->suppress_errors();
 		$order_count = $this->count();
@@ -243,7 +243,7 @@ class WooCommerce_Custom_Orders_Table_CLI extends WP_CLI_Command {
 	 *
 	 * @param Exception $exception The Exception object.
 	 */
-	public function handle_exceptions( $exception ) {
+	public static function handle_exceptions( $exception ) {
 		throw $exception;
 	}
 }

--- a/includes/class-woocommerce-custom-orders-table-cli.php
+++ b/includes/class-woocommerce-custom-orders-table-cli.php
@@ -58,7 +58,7 @@ class WooCommerce_Custom_Orders_Table_CLI extends WP_CLI_Command {
 	 * [--batch-size=<batch-size>]
 	 * : The number of orders to process in each batch.
 	 * ---
-	 * default: 1000
+	 * default: 100
 	 * ---
 	 *
 	 * ## EXAMPLES
@@ -83,7 +83,7 @@ class WooCommerce_Custom_Orders_Table_CLI extends WP_CLI_Command {
 		}
 
 		$assoc_args  = wp_parse_args( $assoc_args, array(
-			'batch-size' => 1000,
+			'batch-size' => 100,
 		) );
 		$order_table = wc_custom_order_table()->get_table_name();
 		$order_types = wc_get_order_types( 'reports' );
@@ -168,7 +168,7 @@ class WooCommerce_Custom_Orders_Table_CLI extends WP_CLI_Command {
 	 * [--batch-size=<batch-size>]
 	 * : The number of orders to process in each batch.
 	 * ---
-	 * default: 1000
+	 * default: 100
 	 * ---
 	 *
 	 * [--batch=<batch>]
@@ -197,7 +197,7 @@ class WooCommerce_Custom_Orders_Table_CLI extends WP_CLI_Command {
 		}
 
 		$assoc_args  = wp_parse_args( $assoc_args, array(
-			'batch-size' => 1000,
+			'batch-size' => 100,
 			'batch'      => 1,
 		) );
 		$progress    = WP_CLI\Utils\make_progress_bar( 'Order Data Migration', $order_count );

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -112,6 +112,28 @@ class CLITest extends TestCase {
 		);
 	}
 
+	/**
+	 * @link https://github.com/liquidweb/woocommerce-custom-orders-table/issues/56
+	 */
+	public function test_migrate_handles_exceptions() {
+		$this->toggle_use_custom_table( false );
+		$order_ids = $this->generate_orders( 3 );
+		$this->toggle_use_custom_table( true );
+
+		// Break the billing email on the first item.
+		update_post_meta( $order_ids[0], '_billing_email', 'this is not an email address' );
+
+		$this->cli->migrate();
+
+		$this->assertEquals(
+			2,
+			$this->count_orders_in_table_with_ids( $order_ids ),
+			'Expected to only see two orders in the custom table.'
+		);
+
+		$this->assertContains( $order_ids[0], $this->get_skipped_ids() );
+	}
+
 	public function test_migrate_with_duplicate_ids() {
 		$this->toggle_use_custom_table( false );
 		$order_id = WC_Helper_Order::create_order()->get_id();
@@ -161,5 +183,17 @@ class CLITest extends TestCase {
 
 		$this->assertEmpty( get_post_meta( $order1->get_id(), '_billing_email', true ) );
 		$this->assertNotEmpty( get_post_meta( $order2->get_id(), '_billing_email', true ) );
+	}
+
+	/**
+	 * Retrieve the array of skipped IDs from the CLI instance.
+	 *
+	 * @return array
+	 */
+	protected function get_skipped_ids() {
+		$property = new ReflectionProperty( $this->cli, 'skipped_ids' );
+		$property->setAccessible( true );
+
+		return (array) $property->getValue( $this->cli );
 	}
 }


### PR DESCRIPTION
This PR leverages the "woocommerce_caught_exception" action to ensure that any exceptions that are raised during the execution of WooCommerce functions (such as `wc_get_order()`) are escalated and logged accordingly by WP-CLI.

Additionally, this PR lowers the default batch size for `migrate`/`backfill` from 1000 to 100, which results in more frequent database queries but a lower memory footprint, which will be important for less-powerful servers (such as in #49).

Fixes #56.