### PR TITLE
Prevent duplicate IDs on order/refund save

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,14 +48,7 @@ matrix:
   #
   # PHP 7.1, WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.2.6
   # - WC_Tests_CRUD_Orders::test_get_billing_email
-  #
-  # Additionally, WordPress trunk seems to be having issues bootstrapping the core test suite,
-  # so those tests are currently permitted to fail.
-  #
-  # Example failure: https://travis-ci.org/liquidweb/woocommerce-custom-orders-table/jobs/382677515
   allow_failures:
-    - php: 7.2
-      env: WP_VERSION=trunk WP_MULTISITE=0 WC_VERSION=latest RUN_PHPCS=1
     - php: 7.2
       env: WP_VERSION=trunk WP_MULTISITE=1 WC_VERSION=latest
     - php: 7.1

--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -15,30 +15,12 @@
 class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 
 	/**
-	 * Set to true when creating so we know to insert meta data.
-	 *
-	 * @var boolean
-	 */
-	protected $creating = false;
-
-	/**
 	 * Hook into WooCommerce database queries related to orders.
 	 */
 	public function __construct() {
 
 		// When creating a WooCommerce order data store request, filter the MySQL query.
 		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', 'WooCommerce_Custom_Orders_Table_Filters::filter_database_queries', 10, 2 );
-	}
-
-	/**
-	 * Create a new order in the database.
-	 *
-	 * @param WC_Order $order The order object, passed by reference.
-	 */
-	public function create( &$order ) {
-		$this->creating = true;
-
-		parent::create( $order );
 	}
 
 	/**
@@ -99,20 +81,15 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 		global $wpdb;
 
 		$table = wc_custom_order_table()->get_table_name();
-		$data  = $wpdb->get_row( $wpdb->prepare(
+		$data  = (array) $wpdb->get_row( $wpdb->prepare(
 			'SELECT * FROM ' . esc_sql( $table ) . ' WHERE order_id = %d LIMIT 1',
 			$order->get_id()
 		), ARRAY_A ); // WPCS: DB call OK.
 
-		// If no matches were found, this record needs to be created.
-		if ( null === $data ) {
-			$this->creating = true;
-
-			return array();
-		}
-
 		// Expand anything that might need assistance.
-		$data['prices_include_tax'] = wc_string_to_bool( $data['prices_include_tax'] );
+		if ( isset( $data['prices_include_tax'] ) ) {
+			$data['prices_include_tax'] = wc_string_to_bool( $data['prices_include_tax'] );
+		}
 
 		return $data;
 	}
@@ -189,7 +166,7 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 		}
 
 		// Insert or update the database record.
-		if ( $this->creating && ! wc_custom_order_table()->row_exists( $order_data['order_id'] ) ) {
+		if ( ! wc_custom_order_table()->row_exists( $order_data['order_id'] ) ) {
 			$inserted = $wpdb->insert( $table, $order_data ); // WPCS: DB call OK.
 
 			if ( 1 !== $inserted ) {
@@ -205,9 +182,6 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 				update_post_meta( $order->get_id(), '_billing_email', $order->get_billing_email() );
 				update_post_meta( $order->get_id(), '_customer_user', $order->get_customer_id() );
 			}
-
-			$this->creating = false;
-
 		} else {
 			$changes = array_intersect_key( $order_data, $order->get_changes() );
 

--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -189,7 +189,7 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 		}
 
 		// Insert or update the database record.
-		if ( $this->creating ) {
+		if ( $this->creating && ! wc_custom_order_table()->row_exists( $order_data['order_id'] ) ) {
 			$inserted = $wpdb->insert( $table, $order_data ); // WPCS: DB call OK.
 
 			if ( 1 !== $inserted ) {

--- a/includes/class-wc-order-refund-data-store-custom-table.php
+++ b/includes/class-wc-order-refund-data-store-custom-table.php
@@ -15,24 +15,6 @@
 class WC_Order_Refund_Data_Store_Custom_Table extends WC_Order_Refund_Data_Store_CPT {
 
 	/**
-	 * Set to true when creating so we know to insert meta data.
-	 *
-	 * @var boolean
-	 */
-	protected $creating = false;
-
-	/**
-	 * Create a new refund in the database.
-	 *
-	 * @param WC_Order_Refund $refund The refund object, passed by reference.
-	 */
-	public function create( &$refund ) {
-		$this->creating = true;
-
-		parent::create( $refund );
-	}
-
-	/**
 	 * Read refund data.
 	 *
 	 * @param WC_Order_Refund $refund      The refund object, passed by reference.
@@ -66,20 +48,15 @@ class WC_Order_Refund_Data_Store_Custom_Table extends WC_Order_Refund_Data_Store
 	public function get_order_data_from_table( $refund ) {
 		global $wpdb;
 
-		$data = $wpdb->get_row( $wpdb->prepare(
+		$data = (array) $wpdb->get_row( $wpdb->prepare(
 			'SELECT * FROM ' . esc_sql( wc_custom_order_table()->get_table_name() ) . ' WHERE order_id = %d LIMIT 1',
 			$refund->get_id()
 		), ARRAY_A ); // WPCS: DB call OK.
 
-		// If no matches were found, this record needs to be created.
-		if ( null === $data ) {
-			$this->creating = true;
-
-			return array();
-		}
-
 		// Expand anything that might need assistance.
-		$data['prices_include_tax'] = wc_string_to_bool( $data['prices_include_tax'] );
+		if ( isset( $data['prices_include_tax'] ) ) {
+			$data['prices_include_tax'] = wc_string_to_bool( $data['prices_include_tax'] );
+		}
 
 		return $data;
 	}
@@ -113,15 +90,12 @@ class WC_Order_Refund_Data_Store_Custom_Table extends WC_Order_Refund_Data_Store
 		);
 
 		// Insert or update the database record.
-		if ( $this->creating && ! wc_custom_order_table()->row_exists( $refund_data['order_id'] ) ) {
+		if ( ! wc_custom_order_table()->row_exists( $refund_data['order_id'] ) ) {
 			$inserted = $wpdb->insert( $table, $refund_data ); // WPCS: DB call OK.
 
 			if ( 1 !== $inserted ) {
 				return;
 			}
-
-			$this->creating = false;
-
 		} else {
 			$refund_data = array_intersect_key( $refund_data, $refund->get_changes() );
 

--- a/includes/class-wc-order-refund-data-store-custom-table.php
+++ b/includes/class-wc-order-refund-data-store-custom-table.php
@@ -113,7 +113,7 @@ class WC_Order_Refund_Data_Store_Custom_Table extends WC_Order_Refund_Data_Store
 		);
 
 		// Insert or update the database record.
-		if ( $this->creating ) {
+		if ( $this->creating && ! wc_custom_order_table()->row_exists( $refund_data['order_id'] ) ) {
 			$inserted = $wpdb->insert( $table, $refund_data ); // WPCS: DB call OK.
 
 			if ( 1 !== $inserted ) {

--- a/includes/class-woocommerce-custom-orders-table.php
+++ b/includes/class-woocommerce-custom-orders-table.php
@@ -66,6 +66,24 @@ class WooCommerce_Custom_Orders_Table {
 	}
 
 	/**
+	 * Simple helper method to determine if a row already exists for the given order ID.
+	 *
+	 * @global $wpdb
+	 *
+	 * @param int $order_id The order ID.
+	 *
+	 * @return bool Whether or not a row already exists for this order ID.
+	 */
+	public function row_exists( $order_id ) {
+		global $wpdb;
+
+		return (bool) $wpdb->get_var( $wpdb->prepare(
+			'SELECT COUNT(order_id) FROM ' . esc_sql( $this->get_table_name() ) . ' WHERE order_id = %d',
+			$order_id
+		) );
+	}
+
+	/**
 	 * Retrieve the database table column => post_meta mapping.
 	 *
 	 * @return array An array of database columns and their corresponding post_meta keys.

--- a/tests/test-core.php
+++ b/tests/test-core.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Tests for the core WooCommerce_Custom_Orders_Table class.
+ *
+ * @package WooCommerce_Custom_Orders_Table
+ * @author  Liquid Web
+ */
+
+class CoreTest extends TestCase {
+
+	public function test_order_row_exists() {
+		$order = WC_Helper_Order::create_order();
+
+		$this->assertTrue( wc_custom_order_table()->row_exists( $order->get_id() ) );
+		$this->assertFalse( wc_custom_order_table()->row_exists( $order->get_id() + 1 ) );
+	}
+}

--- a/tests/test-order-data-store.php
+++ b/tests/test-order-data-store.php
@@ -8,29 +8,6 @@
 
 class OrderDataStoreTest extends TestCase {
 
-	/**
-	 * @requires PHP 5.4 In order to support inline closures for hook callbacks.
-	 */
-	public function test_create() {
-		$instance = new WC_Order_Data_Store_Custom_Table();
-		$property = new ReflectionProperty( $instance, 'creating' );
-		$property->setAccessible( true );
-		$order    = new WC_Order( wp_insert_post( array(
-			'post_type' => 'product',
-		) ) );
-
-		add_action( 'wp_insert_post', function () use ( $property, $instance ) {
-			$this->assertTrue(
-				$property->getValue( $instance ),
-				'As an order is being created, WC_Order_Data_Store_Custom_Table::$creating should be true'
-			);
-		} );
-
-		$instance->create( $order );
-
-		$this->assertEquals( 1, did_action( 'wp_insert_post' ), 'Expected the "wp_insert_post" action to have been fired.' );
-	}
-
 	public function test_loading_a_product_can_automatically_populate_from_meta() {
 		$this->toggle_use_custom_table( false );
 		$order_id = WC_Helper_Order::create_order()->get_id();
@@ -108,7 +85,7 @@ class OrderDataStoreTest extends TestCase {
 		$order->set_customer_ip_address( '127.0.0.1' );
 		$order->set_customer_user_agent( 'PHPUnit' );
 
-		$this->invoke_update_post_meta( $order, true );
+		$this->invoke_update_post_meta( $order );
 
 		$row = $this->get_order_row( $order->get_id() );
 
@@ -124,7 +101,7 @@ class OrderDataStoreTest extends TestCase {
 		$order = WC_Helper_Order::create_order();
 		$order->set_customer_user_agent( 'PHPUnit' );
 
-		$this->invoke_update_post_meta( $order, true );
+		$this->invoke_update_post_meta( $order );
 
 		$row = $this->get_order_row( $order->get_id() );
 
@@ -334,17 +311,10 @@ class OrderDataStoreTest extends TestCase {
 	/**
 	 * Shortcut for setting up reflection methods + properties for update_post_meta().
 	 *
-	 * @param WC_Order $order    The order object, passed by reference.
-	 * @param bool     $creating Optional. The value 'creating' property in the new instance.
-	 *                           Default is false.
+	 * @param WC_Order $order The order object, passed by reference.
 	 */
-	protected function invoke_update_post_meta( &$order, $creating = false ) {
+	protected function invoke_update_post_meta( &$order ) {
 		$instance = new WC_Order_Data_Store_Custom_Table();
-
-		$property = new ReflectionProperty( $instance, 'creating' );
-		$property->setAccessible( true );
-		$property->setValue( $instance, (bool) $creating );
-
 		$method   = new ReflectionMethod( $instance, 'update_post_meta' );
 		$method->setAccessible( true );
 		$method->invokeArgs( $instance, array( &$order ) );

--- a/tests/test-order-data-store.php
+++ b/tests/test-order-data-store.php
@@ -117,6 +117,20 @@ class OrderDataStoreTest extends TestCase {
 		$this->assertEquals( 'PHPUnit', $row['customer_user_agent'] );
 	}
 
+	/**
+	 * @link https://github.com/liquidweb/woocommerce-custom-orders-table/issues/49
+	 */
+	public function test_update_post_meta_for_existing_order_id() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_customer_user_agent( 'PHPUnit' );
+
+		$this->invoke_update_post_meta( $order, true );
+
+		$row = $this->get_order_row( $order->get_id() );
+
+		$this->assertEquals( 'PHPUnit', $row['customer_user_agent'] );
+	}
+
 	public function test_get_order_id_by_order_key() {
 		$order = WC_Helper_Order::create_order();
 		$instance = new WC_Order_Data_Store_Custom_Table();

--- a/tests/test-order-refund-data-store.php
+++ b/tests/test-order-refund-data-store.php
@@ -63,7 +63,7 @@ class OrderRefundDataStoreTest extends TestCase {
 		) );
 		$refund->set_reason( 'Different reason' );
 
-		$this->invoke_update_post_meta( $refund, true );
+		$this->invoke_update_post_meta( $refund );
 
 		$row = $this->get_order_row( $refund->get_id() );
 
@@ -74,16 +74,9 @@ class OrderRefundDataStoreTest extends TestCase {
 	 * Shortcut for setting up reflection methods + properties for update_post_meta().
 	 *
 	 * @param WC_Order_Refund $refund   The order refund object, passed by reference.
-	 * @param bool            $creating Optional. The value 'creating' property in the new
-	 *                                  instance. Default is false.
 	 */
-	protected function invoke_update_post_meta( &$refund, $creating = false ) {
+	protected function invoke_update_post_meta( &$refund ) {
 		$instance = new WC_Order_Refund_Data_Store_Custom_Table();
-
-		$property = new ReflectionProperty( $instance, 'creating' );
-		$property->setAccessible( true );
-		$property->setValue( $instance, (bool) $creating );
-
 		$method   = new ReflectionMethod( $instance, 'update_post_meta' );
 		$method->setAccessible( true );
 		$method->invokeArgs( $instance, array( &$refund ) );

--- a/tests/test-order-refund-data-store.php
+++ b/tests/test-order-refund-data-store.php
@@ -50,4 +50,42 @@ class OrderRefundDataStoreTest extends TestCase {
 		$this->assertEquals( $this->user, $row['refunded_by'] );
 		$this->assertEquals( 'For testing', $row['reason'] );
 	}
+
+	/**
+	 * @link https://github.com/liquidweb/woocommerce-custom-orders-table/issues/49
+	 */
+	public function test_update_post_meta_handles_duplicate_ids() {
+		$order  = WC_Helper_Order::create_order();
+		$refund = wc_create_refund( array(
+			'order_id' => $order->get_id(),
+			'amount'   => 7,
+			'reason'   => 'For testing',
+		) );
+		$refund->set_reason( 'Different reason' );
+
+		$this->invoke_update_post_meta( $refund, true );
+
+		$row = $this->get_order_row( $refund->get_id() );
+
+		$this->assertEquals( 'Different reason', $row['reason'] );
+	}
+
+	/**
+	 * Shortcut for setting up reflection methods + properties for update_post_meta().
+	 *
+	 * @param WC_Order_Refund $refund   The order refund object, passed by reference.
+	 * @param bool            $creating Optional. The value 'creating' property in the new
+	 *                                  instance. Default is false.
+	 */
+	protected function invoke_update_post_meta( &$refund, $creating = false ) {
+		$instance = new WC_Order_Refund_Data_Store_Custom_Table();
+
+		$property = new ReflectionProperty( $instance, 'creating' );
+		$property->setAccessible( true );
+		$property->setValue( $instance, (bool) $creating );
+
+		$method   = new ReflectionMethod( $instance, 'update_post_meta' );
+		$method->setAccessible( true );
+		$method->invokeArgs( $instance, array( &$refund ) );
+	}
 }


### PR DESCRIPTION
On a few different occasions (#49, #47, #58), users have reported errors similar to:

> Error: A database error occurred while migrating order XXX: Duplicate entry 'XXX' for key 'PRIMARY'

These errors were the result of `WC_Order_Data_Store_Custom_Table::$creating` not always being set properly, so the plugin would sometimes try to `INSERT` rather than `UPDATE` the corresponding database row.

Additionally, since the `WC_Order_Refund_Data_Store_Custom_Table` from #52 — which this PR depends upon — was largely copied from `WC_Order_Data_Store_Custom_Table` (I _really_ can't wait until we can use PHP traits in WordPress!), that class would have run into the same issue.

This PR simplifies the logic around the data stores' `update_post_meta()` methods, explicitly checking whether or not a corresponding database row exists and, if not, explicitly inserting it. This enables us to remove the less-than-ideal `$creating` properties and avoid duplicate IDs.

Blocked by #52. Fixes #47, fixes #49.