### PR TITLE
Rename CLITest::init() to CLITest::init_cli() to avoid conflicting with WP_HTTP_TestCase::init()

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -550,16 +550,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.6",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712"
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
-                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
                 "shasum": ""
             },
             "require": {
@@ -571,12 +571,12 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -609,7 +609,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-04-18T13:57:24+00:00"
+            "time": "2018-08-05T17:53:17+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1564,16 +1564,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.2.3",
+            "version": "3.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27"
+                "reference": "628a481780561150481a9ec74709092b9759b3ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4842476c434e375f9d3182ff7b89059583aa8b27",
-                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/628a481780561150481a9ec74709092b9759b3ec",
+                "reference": "628a481780561150481a9ec74709092b9759b3ec",
                 "shasum": ""
             },
             "require": {
@@ -1611,7 +1611,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-02-20T21:35:23+00:00"
+            "time": "2018-07-26T23:47:18+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -1705,30 +1705,31 @@
         },
         {
             "name": "wimg/php-compatibility",
-            "version": "8.1.0",
+            "version": "8.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/wimg/PHPCompatibility.git",
-                "reference": "4ac01e4fe8faaa4f8d3b3cd06ea92e5418ce472e"
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wimg/PHPCompatibility/zipball/4ac01e4fe8faaa4f8d3b3cd06ea92e5418ce472e",
-                "reference": "4ac01e4fe8faaa4f8d3b3cd06ea92e5418ce472e",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
+                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.2 || ^3.0.2"
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
             },
             "conflict": {
                 "squizlabs/php_codesniffer": "2.6.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
             "autoload": {
@@ -1738,7 +1739,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "LGPL-3.0"
+                "LGPL-3.0-or-later"
             ],
             "authors": [
                 {
@@ -1753,7 +1754,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-12-27T21:58:38+00:00"
+            "time": "2018-07-17T13:42:26+00:00"
         },
         {
             "name": "woocommerce/woocommerce",
@@ -1761,12 +1762,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce.git",
-                "reference": "2aec467de814873817dea405a15b8d23c69f1f50"
+                "reference": "e1255de71709d9e7cd8caa143c56fb4d60ab7101"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce/zipball/2aec467de814873817dea405a15b8d23c69f1f50",
-                "reference": "2aec467de814873817dea405a15b8d23c69f1f50",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce/zipball/e1255de71709d9e7cd8caa143c56fb4d60ab7101",
+                "reference": "e1255de71709d9e7cd8caa143c56fb4d60ab7101",
                 "shasum": ""
             },
             "require": {
@@ -1797,7 +1798,7 @@
             ],
             "description": "An eCommerce toolkit that helps you sell anything. Beautifully.",
             "homepage": "https://woocommerce.com/",
-            "time": "2018-05-23T11:56:35+00:00"
+            "time": "2018-09-10T22:29:13+00:00"
         },
         {
             "name": "woocommerce/woocommerce-git-hooks",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -29,6 +29,15 @@
 			-->
 			<exclude>./vendor/woocommerce/woocommerce/tests/unit-tests/api/system-status.php</exclude>
 			<exclude>./vendor/woocommerce/woocommerce/tests/unit-tests/api/v2/system-status.php</exclude>
+
+			<!--
+				Combinations of PHP < 7.2 and WooCommerce < 3.4 are failing due to the
+				WC_Tests_Product_CSV_Importer::test_import() test, which relies on an external HTTP
+				request that's failing.
+
+				@link https://github.com/woocommerce/woocommerce/commit/0e785d46146c04f05d4ed5bc06e9ea2d575553b0
+			-->
+			<exclude>./vendor/woocommerce/woocommerce/tests/unit-tests/importer/product.php</exclude>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,6 +28,7 @@
 				@link https://github.com/woocommerce/woocommerce/pull/18493
 			-->
 			<exclude>./vendor/woocommerce/woocommerce/tests/unit-tests/api/system-status.php</exclude>
+			<exclude>./vendor/woocommerce/woocommerce/tests/unit-tests/api/v2/system-status.php</exclude>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -18,7 +18,7 @@ class CLITest extends TestCase {
 	/**
 	 * @before
 	 */
-	public function init() {
+	public function init_cli() {
 		$this->cli = new WooCommerce_Custom_Orders_Table_CLI();
 	}
 


### PR DESCRIPTION
Newer releases of WooCommerce include a static `WP_HTTP_TestCase` method, which conflicts with our `CLITest::init()` (which is a `@before` method).

This PR renames the latter to `CLITest::init_cli()`.