### PR TITLE
Refactor the migration CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Orders are queried in batches (determined via the `--batch-size` option) in orde
 
 <dl>
 	<dt>batch-size</dt>
-	<dd>The number of orders to process in each batch. Default is 1000 orders.</dd>
+	<dd>The number of orders to process in each batch. Default is 100 orders.</dd>
 </dl>
 
 
@@ -67,9 +67,7 @@ This command does the opposite of `migrate`, looping through the orders table an
 
 <dl>
 	<dt>batch-size</dt>
-	<dd>The number of orders to process in each batch. Default is 1000 orders.</dd>
-	<dt>batch</dt>
-	<dd>The batch number to start from when migrating data. Default is 1.</dd>
+	<dd>The number of orders to process in each batch. Default is 100 orders.</dd>
 </dl>
 
 ## Contributing

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "woocommerce/woocommerce": "dev-master",
     "woocommerce/woocommerce-git-hooks": "*",
     "woocommerce/woocommerce-sniffs": "^0.0.1",
+    "wp-cli/wp-cli": "^2.0",
     "wp-coding-standards/wpcs": "^0.14"
   },
   "autoload-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "17d7b547cf0e4dc5b030877ca4a1850d",
+    "content-hash": "5c7399037a53639b7a6d968b002d095d",
     "packages": [],
     "packages-dev": [
         {
@@ -248,6 +248,52 @@
                 "instantiate"
             ],
             "time": "2015-06-14T21:17:01+00:00"
+        },
+        {
+            "name": "mustache/mustache",
+            "version": "v2.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bobthecow/mustache.php.git",
+                "reference": "fe8fe72e9d580591854de404cc59a1b83ca4d19e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bobthecow/mustache.php/zipball/fe8fe72e9d580591854de404cc59a1b83ca4d19e",
+                "reference": "fe8fe72e9d580591854de404cc59a1b83ca4d19e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.4"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~1.11",
+                "phpunit/phpunit": "~3.7|~4.0|~5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Mustache": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Justin Hileman",
+                    "email": "justin@justinhileman.info",
+                    "homepage": "http://justinhileman.com"
+                }
+            ],
+            "description": "A Mustache implementation in PHP.",
+            "homepage": "https://github.com/bobthecow/mustache.php",
+            "keywords": [
+                "mustache",
+                "templating"
+            ],
+            "time": "2017-07-11T12:54:05+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1004,6 +1050,100 @@
             "time": "2017-08-03T14:08:16+00:00"
         },
         {
+            "name": "ramsey/array_column",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/array_column.git",
+                "reference": "f8e52eb28e67eb50e613b451dd916abcf783c1db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/array_column/zipball/f8e52eb28e67eb50e613b451dd916abcf783c1db",
+                "reference": "f8e52eb28e67eb50e613b451dd916abcf783c1db",
+                "shasum": ""
+            },
+            "require-dev": {
+                "jakub-onderka/php-parallel-lint": "0.8.*",
+                "phpunit/phpunit": "~4.5",
+                "satooshi/php-coveralls": "0.6.*",
+                "squizlabs/php_codesniffer": "~2.2"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/array_column.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Ramsey",
+                    "homepage": "http://benramsey.com"
+                }
+            ],
+            "description": "Provides functionality for array_column() to projects using PHP earlier than version 5.5.",
+            "homepage": "https://github.com/ramsey/array_column",
+            "keywords": [
+                "array",
+                "array_column",
+                "column"
+            ],
+            "time": "2015-03-20T22:07:39+00:00"
+        },
+        {
+            "name": "rmccue/requests",
+            "version": "v1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rmccue/Requests.git",
+                "reference": "87932f52ffad70504d93f04f15690cf16a089546"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rmccue/Requests/zipball/87932f52ffad70504d93f04f15690cf16a089546",
+                "reference": "87932f52ffad70504d93f04f15690cf16a089546",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2"
+            },
+            "require-dev": {
+                "requests/test-server": "dev-master"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Requests": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Ryan McCue",
+                    "homepage": "http://ryanmccue.info"
+                }
+            ],
+            "description": "A HTTP library written in PHP, for human beings.",
+            "homepage": "http://github.com/rmccue/Requests",
+            "keywords": [
+                "curl",
+                "fsockopen",
+                "http",
+                "idna",
+                "ipv6",
+                "iri",
+                "sockets"
+            ],
+            "time": "2016-10-13T00:11:37+00:00"
+        },
+        {
             "name": "sebastian/code-unit-reverse-lookup",
             "version": "1.0.1",
             "source": {
@@ -1614,6 +1754,55 @@
             "time": "2018-07-26T23:47:18+00:00"
         },
         {
+            "name": "symfony/finder",
+            "version": "v3.3.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "baea7f66d30854ad32988c11a09d7ffd485810c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/baea7f66d30854ad32988c11a09d7ffd485810c4",
+                "reference": "baea7f66d30854ad32988c11a09d7ffd485810c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-06-01T21:01:25+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.1.0",
             "source": {
@@ -1873,6 +2062,162 @@
                 "wordpress"
             ],
             "time": "2017-12-21T22:52:52+00:00"
+        },
+        {
+            "name": "wp-cli/mustangostang-spyc",
+            "version": "0.6.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-cli/spyc.git",
+                "reference": "6aa0b4da69ce9e9a2c8402dab8d43cf32c581cc7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-cli/spyc/zipball/6aa0b4da69ce9e9a2c8402dab8d43cf32c581cc7",
+                "reference": "6aa0b4da69ce9e9a2c8402dab8d43cf32c581cc7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.3.*@dev"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Mustangostang\\": "src/"
+                },
+                "files": [
+                    "includes/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "mustangostang",
+                    "email": "vlad.andersen@gmail.com"
+                }
+            ],
+            "description": "A simple YAML loader/dumper class for PHP (WP-CLI fork)",
+            "homepage": "https://github.com/mustangostang/spyc/",
+            "time": "2017-04-25T11:26:20+00:00"
+        },
+        {
+            "name": "wp-cli/php-cli-tools",
+            "version": "v0.11.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-cli/php-cli-tools.git",
+                "reference": "f99308f92487efe18b5aac2057240fe5bb542374"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/f99308f92487efe18b5aac2057240fe5bb542374",
+                "reference": "f99308f92487efe18b5aac2057240fe5bb542374",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">= 5.3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "cli": "lib/"
+                },
+                "files": [
+                    "lib/cli/cli.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "James Logsdon",
+                    "email": "jlogsdon@php.net",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Daniel Bachhuber",
+                    "email": "daniel@handbuilt.co",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Console utilities for PHP",
+            "homepage": "http://github.com/wp-cli/php-cli-tools",
+            "keywords": [
+                "cli",
+                "console"
+            ],
+            "time": "2018-08-22T10:11:06+00:00"
+        },
+        {
+            "name": "wp-cli/wp-cli",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-cli/wp-cli.git",
+                "reference": "8b47483c730b592ca956f1447bb064e90606e4ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/8b47483c730b592ca956f1447bb064e90606e4ba",
+                "reference": "8b47483c730b592ca956f1447bb064e90606e4ba",
+                "shasum": ""
+            },
+            "require": {
+                "mustache/mustache": "~2.4",
+                "php": ">=5.4",
+                "ramsey/array_column": "~1.1",
+                "rmccue/requests": "~1.6",
+                "symfony/finder": ">2.7",
+                "wp-cli/mustangostang-spyc": "^0.6.3",
+                "wp-cli/php-cli-tools": "~0.11.2"
+            },
+            "require-dev": {
+                "roave/security-advisories": "dev-master",
+                "wp-cli/db-command": "^1.3 || ^2",
+                "wp-cli/entity-command": "^1.2 || ^2",
+                "wp-cli/extension-command": "^1.1 || ^2",
+                "wp-cli/package-command": "^1 || ^2",
+                "wp-cli/wp-cli-tests": "^2.0.8"
+            },
+            "bin": [
+                "bin/wp",
+                "bin/wp.bat"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "WP_CLI": "php"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WP-CLI framework",
+            "homepage": "https://wp-cli.org",
+            "keywords": [
+                "cli",
+                "wordpress"
+            ],
+            "time": "2018-08-23T23:01:42+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/includes/class-woocommerce-custom-orders-table-cli.php
+++ b/includes/class-woocommerce-custom-orders-table-cli.php
@@ -250,8 +250,16 @@ class WooCommerce_Custom_Orders_Table_CLI extends WP_CLI_Command {
 		$starting    = ( $assoc_args['batch'] - 1 ) * $assoc_args['batch-size'];
 		$order_query = 'SELECT order_id FROM ' . esc_sql( $order_table ) . ' LIMIT %d, %d';
 		$order_data  = $wpdb->get_col( $wpdb->prepare( $order_query, $starting, $assoc_args['batch-size'] ) ); // WPCS: Unprepared SQL ok, DB call ok.
+		$batch_count = 1;
 
 		while ( ! empty( $order_data ) ) {
+			WP_CLI::debug( sprintf(
+				/* Translators: %1$d is the batch number, %2$d is the batch size. */
+				__( 'Beginning batch #%1$d (%2$d orders/batch).', 'woocommerce-custom-orders-table' ),
+				$batch_count,
+				$assoc_args['batch-size']
+			) );
+
 			foreach ( $order_data as $order_id ) {
 				$order = wc_get_order( $order_id );
 
@@ -265,6 +273,7 @@ class WooCommerce_Custom_Orders_Table_CLI extends WP_CLI_Command {
 
 			// Load up the next batch.
 			$order_data = $wpdb->get_col( $wpdb->prepare( $order_query, $starting + $processed, $assoc_args['batch-size'] ) ); // WPCS: Unprepared SQL ok, DB call ok.
+			$batch_count++;
 		}
 
 		$progress->finish();

--- a/includes/class-woocommerce-custom-orders-table-cli.php
+++ b/includes/class-woocommerce-custom-orders-table-cli.php
@@ -243,7 +243,7 @@ class WooCommerce_Custom_Orders_Table_CLI extends WP_CLI_Command {
 			$order = wc_get_order( $order_query->current()->order_id );
 
 			if ( $order ) {
-				$order->get_data_store()->backfill_postmeta( $order );
+				WooCommerce_Custom_Orders_Table::migrate_to_post_meta( $order );
 			}
 
 			$processed++;

--- a/includes/class-woocommerce-custom-orders-table.php
+++ b/includes/class-woocommerce-custom-orders-table.php
@@ -195,11 +195,15 @@ class WooCommerce_Custom_Orders_Table {
 	/**
 	 * Restore an order's data in the post_meta table.
 	 *
+	 * @global $wpdb
+	 *
 	 * @param WC_Abstract_Order $order  The order or refund object, passed by reference.
 	 * @param bool              $delete Optional. Should the row in the custom table be deleted?
 	 *                                  Default is false.
 	 */
 	public static function migrate_to_post_meta( &$order, $delete = false ) {
+		global $wpdb;
+
 		$data = $order->get_data_store()->get_order_data_from_table( $order );
 
 		if ( is_null( $data ) ) {
@@ -214,6 +218,15 @@ class WooCommerce_Custom_Orders_Table {
 			if ( isset( $data[ $column ] ) ) {
 				update_post_meta( $order->get_id(), $meta_key, $data[ $column ] );
 			}
+		}
+
+		// Remove the row from the custom table.
+		if ( true === $delete ) {
+			$wpdb->delete(
+				wc_custom_order_table()->get_table_name(),
+				array( 'order_id' => $order->get_id() ),
+				array( '%d' )
+			);
 		}
 	}
 

--- a/includes/class-woocommerce-custom-orders-table.php
+++ b/includes/class-woocommerce-custom-orders-table.php
@@ -193,6 +193,31 @@ class WooCommerce_Custom_Orders_Table {
 	}
 
 	/**
+	 * Restore an order's data in the post_meta table.
+	 *
+	 * @param WC_Abstract_Order $order  The order or refund object, passed by reference.
+	 * @param bool              $delete Optional. Should the row in the custom table be deleted?
+	 *                                  Default is false.
+	 */
+	public static function migrate_to_post_meta( &$order, $delete = false ) {
+		$data = $order->get_data_store()->get_order_data_from_table( $order );
+
+		if ( is_null( $data ) ) {
+			return;
+		}
+
+		if ( isset( $data['prices_include_tax'] ) ) {
+			$data['prices_include_tax'] = wc_bool_to_string( $data['prices_include_tax'] );
+		}
+
+		foreach ( self::get_postmeta_mapping() as $column => $meta_key ) {
+			if ( isset( $data[ $column ] ) ) {
+				update_post_meta( $order->get_id(), $meta_key, $data[ $column ] );
+			}
+		}
+	}
+
+	/**
 	 * Retrieve the class name of the WooCommerce customer data store.
 	 *
 	 * @return string The data store class name.

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -272,40 +272,19 @@ class CLITest extends TestCase {
 
 	public function test_backfill() {
 		$order_ids = $this->generate_orders( 5 );
-		$index     = 0;
 
 		foreach ( $order_ids as $order_id ) {
 			$this->assertEmpty( get_post_meta( $order_id, '_billing_first_name', true ) );
 		}
 
-		$this->cli->backfill( array(), array(
-			'batch-size' => 2,
-		) );
+		$this->cli->backfill();
 
 		foreach ( $order_ids as $order_id ) {
-			$index++;
-
 			$this->assertNotEmpty(
 				get_post_meta( $order_id, '_billing_email', true ),
-				"The billing email for order #{$index} was not saved to post meta."
+				"The billing email for order {$order_id} was not saved to post meta."
 			);
 		}
-	}
-
-	public function testbackfill_works_in_batches() {
-		global $wpdb;
-
-		$order_ids = $this->generate_orders( 5 );
-
-		$this->cli->backfill( array(), array(
-			'batch-size' => 2,
-		) );
-
-		$this->assertContains( 'LIMIT 5, 2', $wpdb->last_query, 'The batch size should be used to limit query results.' );
-
-		$this->cli->assertReceivedMessage( 'Beginning batch #1 (2 orders/batch).', 'debug' );
-		$this->cli->assertReceivedMessage( 'Beginning batch #2 (2 orders/batch).', 'debug' );
-		$this->cli->assertReceivedMessage( 'Beginning batch #3 (2 orders/batch).', 'debug' );
 	}
 
 	public function test_backfill_when_an_order_has_been_deleted() {

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -292,6 +292,22 @@ class CLITest extends TestCase {
 		}
 	}
 
+	public function testbackfill_works_in_batches() {
+		global $wpdb;
+
+		$order_ids = $this->generate_orders( 5 );
+
+		$this->cli->backfill( array(), array(
+			'batch-size' => 2,
+		) );
+
+		$this->assertContains( 'LIMIT 5, 2', $wpdb->last_query, 'The batch size should be used to limit query results.' );
+
+		$this->cli->assertReceivedMessage( 'Beginning batch #1 (2 orders/batch).', 'debug' );
+		$this->cli->assertReceivedMessage( 'Beginning batch #2 (2 orders/batch).', 'debug' );
+		$this->cli->assertReceivedMessage( 'Beginning batch #3 (2 orders/batch).', 'debug' );
+	}
+
 	public function test_backfill_when_an_order_has_been_deleted() {
 		$order1 = WC_Helper_Order::create_order();
 		$order2 = WC_Helper_Order::create_order();

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -111,7 +111,7 @@ class CLITest extends TestCase {
 	 *
 	 * @see DataStoreTest::test_populate_from_meta_handles_errors()
 	 */
-	public function test_migrate_stops_on_database_error() {
+	public function test_migrate_skips_on_database_error() {
 		global $wpdb;
 
 		// This test will trigger a DB error due to the duplicate order key.
@@ -128,7 +128,7 @@ class CLITest extends TestCase {
 
 		$this->cli->migrate();
 
-		$this->cli->assertReceivedMessageContaining( "Duplicate entry '' for key 'order_key'", 'error' );
+		$this->cli->assertReceivedMessageContaining( "Duplicate entry '' for key 'order_key'", 'warning' );
 	}
 
 	public function test_migrate_catches_infinite_loops() {
@@ -240,6 +240,34 @@ class CLITest extends TestCase {
 		$this->cli->migrate();
 
 		$this->assertSame( 1, WP_CLI::$__counts['warning'], 'A warning should have been displayed.' );
+	}
+
+	public function test_migrate_output_when_items_were_skipped() {
+		global $wpdb;
+
+		$wpdb->suppress_errors();
+
+		$this->toggle_use_custom_table( false );
+		$order1 = WC_Helper_Order::create_order();
+		$order1->set_order_key( 'first' );
+		$order1->save();
+		$order2 = WC_Helper_Order::create_order();
+		$order2->set_order_key( 'first' );
+		$order2->save();
+		$order3 = WC_Helper_Order::create_order();
+		$order3->set_order_key( 'third' );
+		$order3->save();
+		$this->toggle_use_custom_table( true );
+
+		$this->cli->migrate();
+
+		$this->assertEquals(
+			2,
+			$this->count_orders_in_table_with_ids( array( $order1->get_id(), $order3->get_id() ) ),
+			'Expected to only see two orders in the custom table.'
+		);
+
+		$this->cli->assertReceivedMessage( '2 orders were migrated, with 1 skipped.', 'warning' );
 	}
 
 	public function test_backfill() {

--- a/tests/test-core.php
+++ b/tests/test-core.php
@@ -14,4 +14,71 @@ class CoreTest extends TestCase {
 		$this->assertTrue( wc_custom_order_table()->row_exists( $order->get_id() ) );
 		$this->assertFalse( wc_custom_order_table()->row_exists( $order->get_id() + 1 ) );
 	}
+
+	public function test_migrate_to_post_meta() {
+		$order    = WC_Helper_Order::create_order();
+		$row      = $this->get_order_row( $order->get_id() );
+		$mapping  = WooCommerce_Custom_Orders_Table::get_postmeta_mapping();
+
+		// For versions < WooCommerce 3.3, a few fields may be set.
+		unset( $mapping['billing_email'], $mapping['customer_id'] );
+
+		foreach ( $mapping as $column => $meta_key ) {
+			$this->assertEmpty( get_post_meta( $order->get_id(), $meta_key, true ) );
+		}
+
+		WooCommerce_Custom_Orders_Table::migrate_to_post_meta( $order );
+
+		foreach ( $mapping as $column => $meta_key ) {
+			$this->assertEquals(
+				$row[ $column ],
+				get_post_meta( $order->get_id(), $meta_key, true ),
+				"Value of the $meta_key meta key did not meet expectations."
+			);
+		}
+	}
+
+	public function test_migrate_to_post_meta_with_refunds() {
+		$order    = WC_Helper_Order::create_order();
+		$refund   = wc_create_refund( array(
+			'order_id' => $order->get_id(),
+			'amount'   => 5,
+			'reason'   => 'For testing',
+		) );
+		$row      = $this->get_order_row( $refund->get_id() );
+		$mapping  = WooCommerce_Custom_Orders_Table::get_postmeta_mapping();
+
+		// For versions < WooCommerce 3.3, a few fields may be set.
+		unset( $mapping['billing_email'], $mapping['customer_id'] );
+
+		WooCommerce_Custom_Orders_Table::migrate_to_post_meta( $refund );
+
+		foreach ( $mapping as $column => $meta_key ) {
+			$this->assertEquals(
+				$row[ $column ],
+				get_post_meta( $refund->get_id(), $meta_key, true ),
+				"Value of the $meta_key meta key did not meet expectations."
+			);
+		}
+	}
+
+	public function test_migrate_to_post_meta_returns_early_if_table_row_is_empty() {
+		$this->toggle_use_custom_table( false );
+		$order = WC_Helper_Order::create_order();
+		$this->toggle_use_custom_table( true );
+
+		$last_changed = wp_cache_get( 'last_changed', 'posts' );
+
+		WooCommerce_Custom_Orders_Table::migrate_to_post_meta( $order );
+
+		$this->assertEquals(
+			$last_changed,
+			wp_cache_get( 'last_changed', 'posts' ),
+			'No calls to update_post_meta() should have been made.'
+		);
+	}
+
+	public function test_migrate_to_post_meta_can_delete_table_rows() {
+		$this->markTestIncomplete();
+	}
 }

--- a/tests/test-core.php
+++ b/tests/test-core.php
@@ -79,6 +79,10 @@ class CoreTest extends TestCase {
 	}
 
 	public function test_migrate_to_post_meta_can_delete_table_rows() {
-		$this->markTestIncomplete();
+		$order = WC_Helper_Order::create_order();
+
+		WooCommerce_Custom_Orders_Table::migrate_to_post_meta( $order, true );
+
+		$this->assertEmpty( $this->get_order_row( $order->get_id() ) );
 	}
 }

--- a/tests/test-order-data-store.php
+++ b/tests/test-order-data-store.php
@@ -269,45 +269,6 @@ class OrderDataStoreTest extends TestCase {
 		$this->assertInstanceOf( 'WP_Error', $order1->get_data_store()->populate_from_meta( $order2 ) );
 	}
 
-	public function test_backfill_postmeta() {
-		$order    = WC_Helper_Order::create_order();
-		$row      = $this->get_order_row( $order->get_id() );
-		$mapping  = WooCommerce_Custom_Orders_Table::get_postmeta_mapping();
-
-		// For versions < WooCommerce 3.3, a few fields may be set.
-		unset( $mapping['billing_email'], $mapping['customer_id'] );
-
-		foreach ( $mapping as $column => $meta_key ) {
-			$this->assertEmpty( get_post_meta( $order->get_id(), $meta_key, true ) );
-		}
-
-		$order->get_data_store()->backfill_postmeta( $order );
-
-		foreach ( $mapping as $column => $meta_key ) {
-			$this->assertEquals(
-				$row[ $column ],
-				get_post_meta( $order->get_id(), $meta_key, true ),
-				"Value of the $meta_key meta key did not meet expectations."
-			);
-		}
-	}
-
-	public function test_backfill_postmeta_returns_early_if_table_row_is_empty() {
-		$this->toggle_use_custom_table( false );
-		$order = WC_Helper_Order::create_order();
-		$this->toggle_use_custom_table( true );
-
-		$last_changed = wp_cache_get( 'last_changed', 'posts' );
-
-		$order->get_data_store()->backfill_postmeta( $order );
-
-		$this->assertEquals(
-			$last_changed,
-			wp_cache_get( 'last_changed', 'posts' ),
-			'No calls to update_post_meta() should have been made.'
-		);
-	}
-
 	/**
 	 * Shortcut for setting up reflection methods + properties for update_post_meta().
 	 *


### PR DESCRIPTION
This PR overhauls the migration script to clean up loops and provide more actionable feedback during migration.

Fixes #57, fixes #62. Blocked by #78.