### PR TITLE
Bump the 'WC tested up to' value to 3.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,49 +9,31 @@ cache:
   directories:
     - $HOME/.composer/cache
 
+php:
+  - 7.2
+  - 7.1
+  - 7.0
+
+env:
+  - WP_VERSION=latest WC_VERSION=latest
+  - WP_VERSION=latest WC_VERSION=3.4.5
+  - WP_VERSION=latest WC_VERSION=3.3.5
+  - WP_VERSION=latest WC_VERSION=3.2.6
+
 matrix:
   fast_finish: true
   include:
-    - php: 7.2
-      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=latest
-    - php: 7.1
-      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=latest
-    - php: 7.0
-      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=latest
-    - php: 7.2
-      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.3.3
-    - php: 7.1
-      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.3.3
-    - php: 7.0
-      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.3.3
-    - php: 7.2
-      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.2.6
-    - php: 7.1
-      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.2.6
-    - php: 7.0
-      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.2.6
-    # Run PHP_CodeSniffer on a bleeding-edge configuration.
-    - php: 7.2
-      env: WP_VERSION=trunk WP_MULTISITE=0 WC_VERSION=latest RUN_PHPCS=1
-    # WordPress Multisite on the latest
-    - php: 7.2
-      env: WP_VERSION=trunk WP_MULTISITE=1 WC_VERSION=latest
+    - name: Coding Standards
+      php: 7.2
+      env: WP_VERSION=trunk WC_VERSION=latest RUN_PHPCS=1
     # Generate code coverage from PHP 7.1.
-    - php: 7.1
+    - name: Code Coverage
+      php: 7.2
       env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=latest RUN_CODE_COVERAGE=1
 
-  # The following WooCommerce core test currently fails in multisite, with or without this
-  # plugin being active:
-  #
-  # PHP 7.2, WP_VERSION=trunk WP_MULTISITE=1 WC_VERSION=latest
-  # - WC_Tests_Setup_Functions::test_wizard_in_cart_payment_gateways()
-  #
-  # PHP 7.1, WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.2.6
-  # - WC_Tests_CRUD_Orders::test_get_billing_email
   allow_failures:
-    - php: 7.2
-      env: WP_VERSION=trunk WP_MULTISITE=1 WC_VERSION=latest
-    - php: 7.1
+    - name: Code Coverage
+      php: 7.2
       env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=latest RUN_CODE_COVERAGE=1
 
 before_script:

--- a/tests/compat.php
+++ b/tests/compat.php
@@ -12,7 +12,7 @@
  *
  * @ticket https://github.com/woocommerce/woocommerce/pull/20222
  */
-if ( version_compare( WC_VERSION, '3.4.4', '<=' ) ) {
+if ( version_compare( WC_VERSION, '3.5', '<' ) ) {
 	add_filter( 'woocommerce_before_order_object_save', 'tests_truncate_order_data_store_country_codes' );
 	add_filter( 'woocommerce_order_query_args', 'tests_truncate_order_query_country_codes' );
 }

--- a/woocommerce-custom-orders-table.php
+++ b/woocommerce-custom-orders-table.php
@@ -10,7 +10,7 @@
  * License URI:          https://www.gnu.org/licenses/gpl-2.0.html
  *
  * WC requires at least: 3.2.6
- * WC tested up to:      3.3.0
+ * WC tested up to:      3.5.0
  *
  * @package WooCommerce_Custom_Orders_Table
  * @author  Liquid Web


### PR DESCRIPTION
This commit also streamlines the construction of the Travis CI testing matrix: instead of defining each case individually, define a list of PHP versions and applicable combinations of environment variables.

Fixes #76.