### PR TITLE
Ensure the customer_notes property is populated

### DIFF
--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -47,22 +47,29 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 	}
 
 	/**
-	 * Read order data.
+	 * Read order data from the custom orders table.
 	 *
-	 * @param WC_Order $order The order object, passed by reference.
+	 * If the order does not yet exist, the plugin will attempt to migrate it automatically. This
+	 * behavior can be modified via the "wc_custom_order_table_automatic_migration" filter.
+	 *
+	 * @param WC_Order $order       The order object, passed by reference.
 	 * @param object   $post_object The post object.
 	 */
 	protected function read_order_data( &$order, $post_object ) {
-		global $wpdb;
-
 		$data = $this->get_order_data_from_table( $order );
 
 		if ( ! empty( $data ) ) {
 			$order->set_props( $data );
-
 		} else {
-			// Automatically backfill order data from meta, but allow for disabling.
-			if ( apply_filters( 'wc_custom_order_table_automatic_migration', true ) ) {
+			/**
+			 * Toggle the ability for WooCommerce Custom Orders Table to automatically migrate orders.
+			 *
+			 * @param bool $migrate Whether or not orders should automatically be migrated once they
+			 *                      have been loaded.
+			 */
+			$migrate = apply_filters( 'wc_custom_order_table_automatic_migration', true );
+
+			if ( $migrate ) {
 				$this->populate_from_meta( $order );
 			}
 		}

--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -358,10 +358,14 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 	public function populate_from_meta( &$order, $delete = false ) {
 		global $wpdb;
 
-		$table_data = $this->get_order_data_from_table( $order );
-		$order      = WooCommerce_Custom_Orders_Table::populate_order_from_post_meta( $order );
+		try {
+			$table_data = $this->get_order_data_from_table( $order );
+			$order      = WooCommerce_Custom_Orders_Table::populate_order_from_post_meta( $order );
 
-		$this->update_post_meta( $order );
+			$this->update_post_meta( $order );
+		} catch ( WC_Data_Exception $e ) {
+			return new WP_Error( 'woocommerce-custom-order-table-migration', $e->getMessage() );
+		}
 
 		if ( $wpdb->last_error ) {
 			return new WP_Error( 'woocommerce-custom-order-table-migration', $wpdb->last_error );

--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -75,7 +75,7 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 	 *
 	 * @param WC_Order $order The order object.
 	 *
-	 * @return object The order row, as an associative array.
+	 * @return array The order row, as an associative array.
 	 */
 	public function get_order_data_from_table( $order ) {
 		global $wpdb;
@@ -85,7 +85,13 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 			'SELECT * FROM ' . esc_sql( $table ) . ' WHERE order_id = %d LIMIT 1',
 			$order->get_id()
 		), ARRAY_A ); // WPCS: DB call OK.
-		$post  = get_post( $order->get_id() );
+
+		// Return early if there's no matching row in the orders table.
+		if ( empty( $data ) ) {
+			return array();
+		}
+
+		$post = get_post( $order->get_id() );
 
 		// Expand anything that might need assistance.
 		if ( isset( $data['prices_include_tax'] ) ) {

--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -85,11 +85,15 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 			'SELECT * FROM ' . esc_sql( $table ) . ' WHERE order_id = %d LIMIT 1',
 			$order->get_id()
 		), ARRAY_A ); // WPCS: DB call OK.
+		$post  = get_post( $order->get_id() );
 
 		// Expand anything that might need assistance.
 		if ( isset( $data['prices_include_tax'] ) ) {
 			$data['prices_include_tax'] = wc_string_to_bool( $data['prices_include_tax'] );
 		}
+
+		// Append additional data.
+		$data['customer_note'] = $post->post_excerpt;
 
 		return $data;
 	}

--- a/includes/class-wc-order-refund-data-store-custom-table.php
+++ b/includes/class-wc-order-refund-data-store-custom-table.php
@@ -15,23 +15,25 @@
 class WC_Order_Refund_Data_Store_Custom_Table extends WC_Order_Refund_Data_Store_CPT {
 
 	/**
-	 * Read refund data.
+	 * Read refund data from the custom orders table.
 	 *
-	 * @param WC_Order_Refund $refund      The refund object, passed by reference.
-	 * @param object          $post_object The post object.
+	 * If the refund does not yet exist, the plugin will attempt to migrate it automatically. This
+	 * behavior can be modified via the "wc_custom_order_table_automatic_migration" filter.
+	 *
+	 * @param WC_Refund $order       The refund object, passed by reference.
+	 * @param object    $post_object The post object.
 	 */
-	protected function read_order_data( &$refund, $post_object ) {
-		global $wpdb;
-
-		$data = $this->get_order_data_from_table( $refund );
+	protected function read_order_data( &$order, $post_object ) {
+		$data = $this->get_order_data_from_table( $order );
 
 		if ( ! empty( $data ) ) {
-			$refund->set_props( $data );
-
+			$order->set_props( $data );
 		} else {
-			// Automatically backfill refund data from meta, but allow for disabling.
-			if ( apply_filters( 'wc_custom_order_table_automatic_migration', true ) ) {
-				$this->populate_from_meta( $refund );
+			/** This filter is defined in class-wc-order-data-store-custom-table.php. */
+			$migrate = apply_filters( 'wc_custom_order_table_automatic_migration', true );
+
+			if ( $migrate ) {
+				$this->populate_from_meta( $order );
 			}
 		}
 	}

--- a/tests/test-order-data-store.php
+++ b/tests/test-order-data-store.php
@@ -76,6 +76,19 @@ class OrderDataStoreTest extends TestCase {
 		$this->assertEmpty( $order->get_data_store()->get_order_data_from_table( $order ) );
 	}
 
+	/**
+	 * @ticket https://github.com/liquidweb/woocommerce-custom-orders-table/issues/68
+	 */
+	public function test_get_order_data_from_table_populates_customer_notes() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_customer_note( 'This is a new post excerpt.' );
+		$order->save();
+
+		$order = wc_get_order( $order );
+
+		$this->assertEquals( 'This is a new post excerpt.', $order->get_customer_note() );
+	}
+
 	public function test_update_post_meta_for_new_order() {
 		$order = new WC_Order( wp_insert_post( array(
 			'post_type' => 'product',

--- a/tests/test-order-data-store.php
+++ b/tests/test-order-data-store.php
@@ -282,6 +282,20 @@ class OrderDataStoreTest extends TestCase {
 		$this->assertInstanceOf( 'WP_Error', $order1->get_data_store()->populate_from_meta( $order2 ) );
 	}
 
+	public function test_populate_from_meta_handles_wc_data_exceptions() {
+		$this->toggle_use_custom_table( false );
+		$order = WC_Helper_Order::create_order();
+		$this->toggle_use_custom_table( true );
+
+		// Give an invalid billing email.
+		update_post_meta( $order->get_id(), '_billing_email', 'this is not an email address' );
+
+		// Refresh the instance.
+		$order = wc_get_order( $order->get_id() );
+
+		$this->assertInstanceOf( 'WP_Error', $order->get_data_store()->populate_from_meta( $order ) );
+	}
+
 	/**
 	 * Shortcut for setting up reflection methods + properties for update_post_meta().
 	 *


### PR DESCRIPTION
WooCommerce stores customer-provided notes in the `wp_posts.post_excerpt` column rather than post meta, and overriding the order data store needs to preserve this behavior.

Fixes #68.