### PR TITLE
Set an explicit fallback ORDER BY for the migrate command

### DIFF
--- a/includes/class-woocommerce-custom-orders-table-cli.php
+++ b/includes/class-woocommerce-custom-orders-table-cli.php
@@ -110,7 +110,7 @@ class WooCommerce_Custom_Orders_Table_CLI extends WP_CLI_Command {
 			"SELECT p.ID FROM {$wpdb->posts} p LEFT JOIN " . esc_sql( $order_table ) . ' o ON p.ID = o.order_id
 			WHERE p.post_type IN (' . implode( ', ', array_fill( 0, count( $order_types ), '%s' ) ) . ')
 			AND o.order_id IS NULL
-			ORDER BY p.post_date DESC
+			ORDER BY p.post_date DESC, p.ID DESC
 			LIMIT %d',
 			array_merge( $order_types, array( $assoc_args['batch-size'] ) )
 		);

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -227,11 +227,11 @@ class CLITest extends TestCase {
 		$order = wc_get_order( $order_id );
 		$order->get_total();
 
-		$this->assertEquals( 1, $this->count_orders_in_table_with_ids( $order_id ));
+		$this->assertEquals( 1, $this->count_orders_in_table_with_ids( array( $order_id ) ) );
 
 		$this->cli->migrate();
 
-		$this->assertEquals( 1, $this->count_orders_in_table_with_ids( $order_id ));
+		$this->assertEquals( 1, $this->count_orders_in_table_with_ids( array( $order_id ) ) );
 	}
 
 	public function test_migrate_aborts_if_no_orders_require_migration() {
@@ -263,7 +263,7 @@ class CLITest extends TestCase {
 
 		$this->assertEquals(
 			2,
-			$this->count_orders_in_table_with_ids( array( $order1->get_id(), $order3->get_id() ) ),
+			$this->count_orders_in_table_with_ids( array( $order2->get_id(), $order3->get_id() ) ),
 			'Expected to only see two orders in the custom table.'
 		);
 

--- a/tests/test-order-data-store.php
+++ b/tests/test-order-data-store.php
@@ -13,11 +13,11 @@ class OrderDataStoreTest extends TestCase {
 		$order_id = WC_Helper_Order::create_order()->get_id();
 		$this->toggle_use_custom_table( true );
 
-		$this->assertEquals( 0, $this->count_orders_in_table_with_ids( $order_id ) );
+		$this->assertEquals( 0, $this->count_orders_in_table_with_ids( array( $order_id ) ) );
 
 		$order = wc_get_order( $order_id );
 
-		$this->assertEquals( 1, $this->count_orders_in_table_with_ids( $order->get_id() ) );
+		$this->assertEquals( 1, $this->count_orders_in_table_with_ids( array( $order->get_id() ) ) );
 	}
 
 	/**
@@ -34,7 +34,7 @@ class OrderDataStoreTest extends TestCase {
 		$order = wc_get_order( $order_id );
 
 		$this->assertEmpty( $order->get_total() );
-		$this->assertEquals( 0, $this->count_orders_in_table_with_ids( $order_id ) );
+		$this->assertEquals( 0, $this->count_orders_in_table_with_ids( array( $order_id ) ) );
 	}
 
 	public function test_delete() {


### PR DESCRIPTION
When a test creates multiple test orders within the same second, the resulting products cause MySQL to try to guess which order should come first rather than — as I had assumed — falling back to sorting by ID. As a result, ordering products by p.post_date alone cannot reliably keep two orders sorted the same way, since MySQL may decide to give precedence to any one of the rows with matching timestamps. Further details are [available in MySQL's "ORDER BY Optimization" documentation](https://dev.mysql.com/doc/refman/5.5/en/order-by-optimization.html).

This PR ensures that the `migrate` command explicitly falls back to sorting by `wp_posts.ID` in descending order, which matches the intent of "migrate the most recent orders (which are presumably more likely to be active) first, working backwards historically".

Additionally, this PR cleans up instances where tests were passing integers instead of arrays to `TestCase::count_orders_in_table_with_ids()`, relying on type coercion.

Fixes #83.