### PR TITLE
Replace autoloader implementation

### DIFF
--- a/woocommerce-custom-orders-table.php
+++ b/woocommerce-custom-orders-table.php
@@ -20,10 +20,6 @@
 define( 'WC_CUSTOM_ORDER_TABLE_URL', plugin_dir_url( __FILE__ ) );
 define( 'WC_CUSTOM_ORDER_TABLE_PATH', plugin_dir_path( __FILE__ ) );
 
-// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_set_include_path
-set_include_path( get_include_path() . PATH_SEPARATOR . WC_CUSTOM_ORDER_TABLE_PATH . '/includes/' );
-// phpcs:enable WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_set_include_path
-
 /**
  * Autoloader for plugin files.
  *
@@ -31,11 +27,25 @@ set_include_path( get_include_path() . PATH_SEPARATOR . WC_CUSTOM_ORDER_TABLE_PA
  * conventions, where a class of 'Foo_Bar' would be named 'class-foo-bar.php'.
  *
  * @param string $class The class name to autoload.
+ *
+ * @return void
  */
 function wc_custom_order_table_autoload( $class ) {
-	$class = 'class-' . str_replace( '_', '-', $class );
+	// Bail early if the class/trait/interface is not in the root namespace.
+	if ( strpos( $class, '\\' ) !== false ) {
+		return;
+	}
 
-	return spl_autoload( $class );
+	// Assemble file path and name according to WordPress code style.
+	$filename = strtolower( 'class-' . str_replace( '_', '-', $class ) . '.php' );
+	$filepath = WC_CUSTOM_ORDER_TABLE_PATH . 'includes/' . $filename;
+
+	// Bail if the file name we generated does not exist.
+	if ( ! is_readable( $filepath ) ) {
+		return;
+	}
+
+	include $filepath;
 }
 spl_autoload_register( 'wc_custom_order_table_autoload' );
 


### PR DESCRIPTION
The current autoloader implementation uses `set_include_path()`, which should be avoided.

Since PHP 5.3, there's no valid reason to use `set_include_path()` in application code anymore, as:
- it adds processing overhead and additional filesystem checks to _all_ `include`/`require` statements that follow it;
- following from that, it slows down _all_ other autoloaders as well;
- it can break in environments where the include path is set at the server level and cannot be changed due to security restrictions;
- `spl_autoload_register()` can be fed a callback that does the `include` directly, avoiding any further processing.

This alternative autoloader implementation uses a direct `include` in the callback that avoids the above drawbacks and is closer to the generally accepted approach that is now used by the PHP community (usually in the form of an autoloader generated by Composer).