### PR TITLE
Convert the customer_user_agent to a TEXT column type

### DIFF
--- a/includes/class-woocommerce-custom-orders-table-install.php
+++ b/includes/class-woocommerce-custom-orders-table-install.php
@@ -92,7 +92,7 @@ class WooCommerce_Custom_Orders_Table_Install {
 				prices_include_tax varchar(3) NOT NULL COMMENT 'Did the prices include tax during checkout?',
 				transaction_id varchar(200) NOT NULL COMMENT 'Unique transaction ID',
 				customer_ip_address varchar(40) DEFAULT NULL COMMENT 'The customer\'s IP address',
-				customer_user_agent varchar(200) DEFAULT NULL COMMENT 'The customer\'s User-Agent string',
+				customer_user_agent text DEFAULT NULL COMMENT 'The customer\'s User-Agent string',
 				created_via varchar(200) NOT NULL COMMENT 'Order creation method',
 				date_completed varchar(20) DEFAULT NULL COMMENT 'Date the order was completed',
 				date_paid varchar(20) DEFAULT NULL COMMENT 'Date the order was paid',

--- a/tests/test-installation.php
+++ b/tests/test-installation.php
@@ -190,7 +190,6 @@ class InstallationTest extends TestCase {
 	 *           ["prices_include_tax", 3]
 	 *           ["transaction_id", 200]
 	 *           ["customer_ip_address", 40]
-	 *           ["customer_user_agent", 200]
 	 *           ["created_via", 200]
 	 *           ["date_completed", 20]
 	 *           ["date_paid", 20]
@@ -205,6 +204,13 @@ class InstallationTest extends TestCase {
 			sprintf( 'varchar(%d)', $length ),
 			sprintf( 'Column "%s" did not match the expected VARCHAR length of %d.', $column, $length )
 		);
+	}
+
+	/**
+	 * @ticket https://github.com/liquidweb/woocommerce-custom-orders-table/issues/89
+	 */
+	public function test_user_agent_is_stored_in_text_column() {
+		$this->assert_column_has_type( 'customer_user_agent', 'text' );
 	}
 
 	/**

--- a/tests/test-installation.php
+++ b/tests/test-installation.php
@@ -147,8 +147,6 @@ class InstallationTest extends TestCase {
 	 * @link https://github.com/liquidweb/woocommerce-custom-orders-table/issues/48
 	 */
 	public function test_char_length( $column, $length ) {
-		global $wpdb;
-
 		$this->assert_column_has_type(
 			$column,
 			sprintf( 'char(%d)', $length ),
@@ -158,8 +156,6 @@ class InstallationTest extends TestCase {
 
 	/**
 	 * Test the lengths of VARCHAR fields.
-	 *
-	 * @global $wpdb
 	 *
 	 * @testWith ["order_key", 100]
 	 *           ["billing_index", 255]
@@ -204,8 +200,6 @@ class InstallationTest extends TestCase {
 	 * @link https://github.com/liquidweb/woocommerce-custom-orders-table/issues/48
 	 */
 	public function test_varchar_length( $column, $length ) {
-		global $wpdb;
-
 		$this->assert_column_has_type(
 			$column,
 			sprintf( 'varchar(%d)', $length ),


### PR DESCRIPTION
This PR changes the `customer_user_agent` column from a `VARCHAR(200)` to a `TEXT` column type, providing more space for longer User-Agent strings and fixing #89.

I'm choosing to **not** increment the database version here (since we're still pre-1.0.0) and the column type only needs to be changed if people are having problems with existing User-Agent strings > 200 characters. The change may manually be applied by doing either of the following:

1. Remove the `wc_orders_table_version` option from the site, letting WordPress automatically apply the transformation on the next request.
  - This can be done via WP-CLI: `wp option delete wc_orders_table_version`
2. Run the following SQL query against the database: `ALTER TABLE wp_woocommerce_orders MODIFY customer_user_agent TEXT DEFAULT NULL COMMENT "The customer's User-Agent string";`