### PR TITLE
Store order key as null if empty

### DIFF
--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -126,7 +126,7 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 		$changes    = array();
 		$order_data = array(
 			'order_id'             => $order->get_id( 'edit' ),
-			'order_key'            => $order->get_order_key( 'edit' ),
+			'order_key'            => $order->get_order_key( 'edit' ) ?: null,
 			'customer_id'          => $order->get_customer_id( 'edit' ),
 			'payment_method'       => $order->get_payment_method( 'edit' ),
 			'payment_method_title' => $order->get_payment_method_title( 'edit' ),

--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -126,7 +126,7 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 		$changes    = array();
 		$order_data = array(
 			'order_id'             => $order->get_id( 'edit' ),
-			'order_key'            => $order->get_order_key( 'edit' ) ?: null,
+			'order_key'            => $order->get_order_key( 'edit' ) ? $order->get_order_key( 'edit' ) : null,
 			'customer_id'          => $order->get_customer_id( 'edit' ),
 			'payment_method'       => $order->get_payment_method( 'edit' ),
 			'payment_method_title' => $order->get_payment_method_title( 'edit' ),


### PR DESCRIPTION
If I understand https://github.com/liquidweb/woocommerce-custom-orders-table/issues/96#issuecomment-435893836, a simple fix: if the order key value is falsy, use `null`.