### PR TITLE
Address duplicate order keys

### DIFF
--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -126,7 +126,7 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 		$changes    = array();
 		$order_data = array(
 			'order_id'             => $order->get_id( 'edit' ),
-			'order_key'            => $order->get_order_key( 'edit' ),
+			'order_key'            => $order->get_order_key( 'edit' ) ?: null,
 			'customer_id'          => $order->get_customer_id( 'edit' ),
 			'payment_method'       => $order->get_payment_method( 'edit' ),
 			'payment_method_title' => $order->get_payment_method_title( 'edit' ),

--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -126,7 +126,7 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 		$changes    = array();
 		$order_data = array(
 			'order_id'             => $order->get_id( 'edit' ),
-			'order_key'            => $order->get_order_key( 'edit' ) ?: null,
+			'order_key'            => $order->get_order_key( 'edit' ) ? $order->get_order_key( 'edit' ) : null,
 			'customer_id'          => $order->get_customer_id( 'edit' ),
 			'payment_method'       => $order->get_payment_method( 'edit' ),
 			'payment_method_title' => $order->get_payment_method_title( 'edit' ),

--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -124,9 +124,10 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 
 		$table      = wc_custom_order_table()->get_table_name();
 		$changes    = array();
+		$order_key  = $order->get_order_key( 'edit' );
 		$order_data = array(
 			'order_id'             => $order->get_id( 'edit' ),
-			'order_key'            => $order->get_order_key( 'edit' ) ? $order->get_order_key( 'edit' ) : null,
+			'order_key'            => $order_key ? $order_key : null,
 			'customer_id'          => $order->get_customer_id( 'edit' ),
 			'payment_method'       => $order->get_payment_method( 'edit' ),
 			'payment_method_title' => $order->get_payment_method_title( 'edit' ),

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -234,6 +234,29 @@ class CLITest extends TestCase {
 		$this->assertEquals( 1, $this->count_orders_in_table_with_ids( array( $order_id ) ) );
 	}
 
+	/**
+	 * @ticket https://github.com/liquidweb/woocommerce-custom-orders-table/issues/69
+	 * @ticket https://github.com/liquidweb/woocommerce-custom-orders-table/issues/96
+	 */
+	public function test_migrate_with_duplicate_null_order_ids() {
+		$this->toggle_use_custom_table( false );
+		$order1 = WC_Helper_Order::create_order();
+		$order1->set_order_key( '' );
+		$order1->save();
+		$order2 = WC_Helper_Order::create_order();
+		$order2->set_order_key( '' );
+		$order2->save();
+		$this->toggle_use_custom_table( true );
+
+		$this->cli->migrate();
+
+		$this->assertSame(
+			2,
+			$this->count_orders_in_table_with_ids( array( $order1->get_id(), $order2->get_id() ) ),
+			'Two distinct orders can share a NULL order_key.'
+		);
+	}
+
 	public function test_migrate_aborts_if_no_orders_require_migration() {
 		$this->assertSame( 0, $this->cli->count(), 'Expected to start with 0 orders.' );
 

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -119,16 +119,16 @@ class CLITest extends TestCase {
 
 		$this->toggle_use_custom_table( false );
 		$order1 = WC_Helper_Order::create_order();
-		$order1->set_order_key( '' );
+		$order1->set_order_key( 'some-key' );
 		$order1->save();
 		$order2 = WC_Helper_Order::create_order();
-		$order2->set_order_key( '' );
+		$order2->set_order_key( 'some-key' );
 		$order2->save();
 		$this->toggle_use_custom_table( true );
 
 		$this->cli->migrate();
 
-		$this->cli->assertReceivedMessageContaining( "Duplicate entry '' for key 'order_key'", 'warning' );
+		$this->cli->assertReceivedMessageContaining( "Duplicate entry 'some-key' for key 'order_key'", 'warning' );
 	}
 
 	public function test_migrate_catches_infinite_loops() {

--- a/tests/test-order-data-store.php
+++ b/tests/test-order-data-store.php
@@ -268,10 +268,10 @@ class OrderDataStoreTest extends TestCase {
 
 		$this->toggle_use_custom_table( false );
 		$order1 = WC_Helper_Order::create_order();
-		$order1->set_order_key( '' );
+		$order1->set_order_key( 'some-key' );
 		$order1->save();
 		$order2 = WC_Helper_Order::create_order();
-		$order2->set_order_key( '' );
+		$order2->set_order_key( 'some-key' );
 		$order2->save();
 		$this->toggle_use_custom_table( true );
 


### PR DESCRIPTION
This PR supersedes #97 in addressing issues with duplicate order keys:

When saving an order to the custom table, an empty order key was being stored as `''` (an empty string), rather than explicitly being `NULL`. Since there's a `UNIQUE` key on that column, only one order could have an empty order key, and others would fail due to the uniqueness constraint.

This PR ensures that an empty order key is explicitly being cast as `NULL` as data is being prepared to go into the custom table, avoiding the table constraint.

Fixes #69, fixes #96.