### PR TITLE
Ensure the orders query is adjusted as late as possible.

### DIFF
--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -20,7 +20,7 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 	public function __construct() {
 
 		// When creating a WooCommerce order data store request, filter the MySQL query.
-		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', 'WooCommerce_Custom_Orders_Table_Filters::filter_database_queries', 10, 2 );
+		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', 'WooCommerce_Custom_Orders_Table_Filters::filter_database_queries', PHP_INT_MAX, 2 );
 	}
 
 	/**

--- a/tests/test-filters.php
+++ b/tests/test-filters.php
@@ -94,7 +94,7 @@ class FiltersTest extends TestCase {
 
 		$orders = wc_get_orders( array( '_custom_meta_key' => 'value' ) );
 
-		$this->assertEquals( 1, count($orders) );
+		$this->assertCount( 1, $orders );
 	}
 
 	public function test_filter_database_queries_without_meta_queries() {

--- a/tests/test-filters.php
+++ b/tests/test-filters.php
@@ -81,6 +81,8 @@ class FiltersTest extends TestCase {
 		$order->update_meta_data( '_custom_meta_key', 'value' );
 		$order->save();
 
+		// Because we hook into this filter, we need to ensure that if anyone else also hooks in, that we're
+		// properly handling the resulting postmeta table JOIN clause in the resulting SQL query.
 		add_filter('woocommerce_order_data_store_cpt_get_orders_query', function ( $query, $query_vars ) {
 			if ( ! empty( $query_vars['_custom_meta_key'] ) ) {
 				$query['meta_query'][] = array(

--- a/tests/test-filters.php
+++ b/tests/test-filters.php
@@ -45,6 +45,70 @@ class FiltersTest extends TestCase {
 		], WooCommerce_Custom_Orders_Table_Filters::filter_database_queries( $args, [] ) );
 	}
 
+	public function test_filter_database_queries_with_postmeta() {
+		$args = [
+			'meta_query' => [
+				'relation' => 'AND',
+				'customer_emails' => [
+					'key'     => '_billing_email',
+					'value'   => [ 'test@example.com' ],
+					'compare' => 'IN',
+				],
+				'custom_key' => [
+					'key' => '_custom_meta_key',
+					'value' => 'value',
+				],
+			],
+		];
+
+		$this->assertEquals( [
+			'meta_query' => $args['meta_query'],
+			'_wc_has_meta_columns' => true,
+			'wc_order_meta_query'  => [
+				[
+					'key'      => 'billing_email',
+					'value'    => [ 'test@example.com' ],
+					'compare'  => 'IN',
+					'_old_key' => '_billing_email',
+				],
+			],
+			'meta_query' => [
+				'relation' => 'AND',
+				'customer_emails' => [
+					'key'     => '_billing_email',
+					'value'   => [ 'test@example.com' ],
+					'compare' => 'IN',
+				],
+				'custom_key' => [
+					'key' => '_custom_meta_key',
+					'value' => 'value',
+				],
+			],
+		], WooCommerce_Custom_Orders_Table_Filters::filter_database_queries( $args, [] ) );
+	}
+
+	public function test_wc_get_orders_custom_meta_key() {
+
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data( '_custom_meta_key', 'value' );
+		$order->save();
+
+		add_filter('woocommerce_order_data_store_cpt_get_orders_query', function ( $query, $query_vars ) {
+			if ( ! empty( $query_vars['_custom_meta_key'] ) ) {
+				$query['meta_query'][] = array(
+					'key' => '_custom_meta_key',
+					'value' => esc_attr( $query_vars['_custom_meta_key'] ),
+				);
+			}
+
+			return $query;
+		}, 100, 2);
+
+		$orders = wc_get_orders( array( '_custom_meta_key' => 'value' ) );
+
+		$this->assertEquals( 1, count($orders) );
+	}
+
 	public function test_filter_database_queries_without_meta_queries() {
 		$this->assertEquals( [
 			'foo'                  => 'bar',

--- a/tests/test-filters.php
+++ b/tests/test-filters.php
@@ -72,18 +72,6 @@ class FiltersTest extends TestCase {
 					'_old_key' => '_billing_email',
 				],
 			],
-			'meta_query' => [
-				'relation' => 'AND',
-				'customer_emails' => [
-					'key'     => '_billing_email',
-					'value'   => [ 'test@example.com' ],
-					'compare' => 'IN',
-				],
-				'custom_key' => [
-					'key' => '_custom_meta_key',
-					'value' => 'value',
-				],
-			],
 		], WooCommerce_Custom_Orders_Table_Filters::filter_database_queries( $args, [] ) );
 	}
 


### PR DESCRIPTION
Fixes #125

`filter_database_queries` was being called before other plugins had a chance to include additional meta to the query. This resulted in the premature removal postmeta join from the query, which was causing the error.

This fix ensure the filter is executed at the last possible moment to ensure all plugins and themes have a chance to include meta data in the query.
