### PR TITLE
Permit tests using PHP 7.4 to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ matrix:
       php: nightly
       env: WP_VERSION=trunk WC_VERSION=latest
   allow_failures:
+    - php: 7.4snapshot
     - name: Code Coverage
       php: 7.2
       env: WP_VERSION=latest WC_VERSION=latest RUN_CODE_COVERAGE=1


### PR DESCRIPTION
Since WordPress doesn't yet *offically* support PHP 7.4, mark the tests as optional for now.

Based on a suggestion from @bswatson in #126.