### PR TITLE
Add method_exists check

### DIFF
--- a/includes/class-woocommerce-custom-orders-table.php
+++ b/includes/class-woocommerce-custom-orders-table.php
@@ -186,7 +186,9 @@ class WooCommerce_Custom_Orders_Table {
 						break;
 
 					default:
-						$order->{"set_{$column}"}( $meta );
+						if ( method_exists( $order, "set_{$column}" ) ) {
+							$order->{"set_{$column}"}( $meta );
+						}
 						break;
 				}
 			}


### PR DESCRIPTION
When setting meta, a method was called using a variable name (name of
meta). However, there may be non-standard meta fields, which cause a
fatal error when an attempt to call a non-existant method is used. To
prevent this there is now a check to ensure the method exists before
it is used.