### PR TITLE
Introduce a new QueryIterator class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "phpunit/phpunit": "^6.5",
         "woocommerce/woocommerce-git-hooks": "*",
         "woocommerce/woocommerce-sniffs": "^0.0.9",
-        "wp-cli/wp-cli": "^2.0",
         "wp-coding-standards/wpcs": "^2.2.0"
     },
     "autoload-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a964220680db8aa4990a65c395fc0bd6",
+    "content-hash": "2589834c47db02d958903080c5dc6a65",
     "packages": [
         {
             "name": "composer/installers",
@@ -133,50 +133,6 @@
     ],
     "packages-dev": [
         {
-            "name": "cweagans/composer-patches",
-            "version": "1.6.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/cweagans/composer-patches.git",
-                "reference": "2e6f72a2ad8d59cd7e2b729f218bf42adb14f590"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/2e6f72a2ad8d59cd7e2b729f218bf42adb14f590",
-                "reference": "2e6f72a2ad8d59cd7e2b729f218bf42adb14f590",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.0",
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "composer/composer": "~1.0",
-                "phpunit/phpunit": "~4.6"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "cweagans\\Composer\\Patches"
-            },
-            "autoload": {
-                "psr-4": {
-                    "cweagans\\Composer\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Cameron Eagans",
-                    "email": "me@cweagans.net"
-                }
-            ],
-            "description": "Provides a way to patch Composer packages.",
-            "time": "2019-08-29T20:11:49+00:00"
-        },
-        {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v0.5.0",
             "source": {
@@ -297,52 +253,6 @@
                 "instantiate"
             ],
             "time": "2019-10-21T16:45:58+00:00"
-        },
-        {
-            "name": "mustache/mustache",
-            "version": "v2.13.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/bobthecow/mustache.php.git",
-                "reference": "e95c5a008c23d3151d59ea72484d4f72049ab7f4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/mustache.php/zipball/e95c5a008c23d3151d59ea72484d4f72049ab7f4",
-                "reference": "e95c5a008c23d3151d59ea72484d4f72049ab7f4",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.2.4"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "~1.11",
-                "phpunit/phpunit": "~3.7|~4.0|~5.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Mustache": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Justin Hileman",
-                    "email": "justin@justinhileman.info",
-                    "homepage": "http://justinhileman.com"
-                }
-            ],
-            "description": "A Mustache implementation in PHP.",
-            "homepage": "https://github.com/bobthecow/mustache.php",
-            "keywords": [
-                "mustache",
-                "templating"
-            ],
-            "time": "2019-11-23T21:40:31+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -708,16 +618,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.0.0",
+            "version": "5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "a48807183a4b819072f26e347bbd0b5199a9d15f"
+                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/a48807183a4b819072f26e347bbd0b5199a9d15f",
-                "reference": "a48807183a4b819072f26e347bbd0b5199a9d15f",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
+                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
                 "shasum": ""
             },
             "require": {
@@ -757,30 +667,29 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2020-02-09T09:16:15+00:00"
+            "time": "2020-02-22T12:28:44+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.0.1",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9"
+                "reference": "7462d5f123dfc080dfdf26897032a6513644fc95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
-                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/7462d5f123dfc080dfdf26897032a6513644fc95",
+                "reference": "7462d5f123dfc080dfdf26897032a6513644fc95",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1",
+                "php": "^7.2",
                 "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
-                "ext-tokenizer": "^7.1",
-                "mockery/mockery": "~1",
-                "phpunit/phpunit": "^7.0"
+                "ext-tokenizer": "^7.2",
+                "mockery/mockery": "~1"
             },
             "type": "library",
             "extra": {
@@ -804,7 +713,7 @@
                 }
             ],
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "time": "2019-08-22T18:11:29+00:00"
+            "time": "2020-02-18T18:59:58+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -1261,55 +1170,6 @@
             ],
             "abandoned": true,
             "time": "2018-08-09T05:50:03+00:00"
-        },
-        {
-            "name": "rmccue/requests",
-            "version": "v1.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/rmccue/Requests.git",
-                "reference": "87932f52ffad70504d93f04f15690cf16a089546"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/rmccue/Requests/zipball/87932f52ffad70504d93f04f15690cf16a089546",
-                "reference": "87932f52ffad70504d93f04f15690cf16a089546",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.2"
-            },
-            "require-dev": {
-                "requests/test-server": "dev-master"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Requests": "library/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "ISC"
-            ],
-            "authors": [
-                {
-                    "name": "Ryan McCue",
-                    "homepage": "http://ryanmccue.info"
-                }
-            ],
-            "description": "A HTTP library written in PHP, for human beings.",
-            "homepage": "http://github.com/rmccue/Requests",
-            "keywords": [
-                "curl",
-                "fsockopen",
-                "http",
-                "idna",
-                "ipv6",
-                "iri",
-                "sockets"
-            ],
-            "time": "2016-10-13T00:11:37+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1922,66 +1782,17 @@
             "time": "2020-01-30T22:20:29+00:00"
         },
         {
-            "name": "symfony/finder",
-            "version": "v5.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/finder.git",
-                "reference": "4176e7cb846fe08f32518b7e0ed8462e2db8d9bb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/4176e7cb846fe08f32518b7e0ed8462e2db8d9bb",
-                "reference": "4176e7cb846fe08f32518b7e0ed8462e2db8d9bb",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Finder\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Finder Component",
-            "homepage": "https://symfony.com",
-            "time": "2020-01-04T14:08:26+00:00"
-        },
-        {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.13.1",
+            "version": "v1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3"
+                "reference": "fbdeaec0df06cf3d51c93de80c7eb76e271f5a38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
-                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/fbdeaec0df06cf3d51c93de80c7eb76e271f5a38",
+                "reference": "fbdeaec0df06cf3d51c93de80c7eb76e271f5a38",
                 "shasum": ""
             },
             "require": {
@@ -1993,7 +1804,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.13-dev"
+                    "dev-master": "1.14-dev"
                 }
             },
             "autoload": {
@@ -2026,7 +1837,7 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-11-27T13:56:44+00:00"
+            "time": "2020-01-13T11:15:53+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2070,16 +1881,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.6.0",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925"
+                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/573381c0a64f155a0d9a23f4b0c797194805b925",
-                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/aed98a490f9a8f78468232db345ab9cf606cf598",
+                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598",
                 "shasum": ""
             },
             "require": {
@@ -2114,7 +1925,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2019-11-24T13:36:37+00:00"
+            "time": "2020-02-14T12:15:55+00:00"
         },
         {
             "name": "woocommerce/woocommerce-git-hooks",
@@ -2188,172 +1999,6 @@
                 "wordpress"
             ],
             "time": "2019-11-11T15:48:34+00:00"
-        },
-        {
-            "name": "wp-cli/mustangostang-spyc",
-            "version": "0.6.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/wp-cli/spyc.git",
-                "reference": "6aa0b4da69ce9e9a2c8402dab8d43cf32c581cc7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/spyc/zipball/6aa0b4da69ce9e9a2c8402dab8d43cf32c581cc7",
-                "reference": "6aa0b4da69ce9e9a2c8402dab8d43cf32c581cc7",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "4.3.*@dev"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.5.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Mustangostang\\": "src/"
-                },
-                "files": [
-                    "includes/functions.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "mustangostang",
-                    "email": "vlad.andersen@gmail.com"
-                }
-            ],
-            "description": "A simple YAML loader/dumper class for PHP (WP-CLI fork)",
-            "homepage": "https://github.com/mustangostang/spyc/",
-            "time": "2017-04-25T11:26:20+00:00"
-        },
-        {
-            "name": "wp-cli/php-cli-tools",
-            "version": "v0.11.11",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/wp-cli/php-cli-tools.git",
-                "reference": "fe9c7c44a9e1bf2196ec51dc38da0593dbf2993f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/fe9c7c44a9e1bf2196ec51dc38da0593dbf2993f",
-                "reference": "fe9c7c44a9e1bf2196ec51dc38da0593dbf2993f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">= 5.3.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "cli": "lib/"
-                },
-                "files": [
-                    "lib/cli/cli.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "James Logsdon",
-                    "email": "jlogsdon@php.net",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Daniel Bachhuber",
-                    "email": "daniel@handbuilt.co",
-                    "role": "Maintainer"
-                }
-            ],
-            "description": "Console utilities for PHP",
-            "homepage": "http://github.com/wp-cli/php-cli-tools",
-            "keywords": [
-                "cli",
-                "console"
-            ],
-            "time": "2018-09-04T13:28:00+00:00"
-        },
-        {
-            "name": "wp-cli/wp-cli",
-            "version": "v2.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/wp-cli/wp-cli.git",
-                "reference": "74c949c74708e3a88ad0add70f3236c8675dfd85"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/74c949c74708e3a88ad0add70f3236c8675dfd85",
-                "reference": "74c949c74708e3a88ad0add70f3236c8675dfd85",
-                "shasum": ""
-            },
-            "require": {
-                "cweagans/composer-patches": "^1.6",
-                "ext-curl": "*",
-                "mustache/mustache": "~2.4",
-                "php": "^5.4 || ^7.0",
-                "rmccue/requests": "~1.6",
-                "symfony/finder": ">2.7",
-                "wp-cli/mustangostang-spyc": "^0.6.3",
-                "wp-cli/php-cli-tools": "~0.11.2"
-            },
-            "require-dev": {
-                "roave/security-advisories": "dev-master",
-                "wp-cli/db-command": "^1.3 || ^2",
-                "wp-cli/entity-command": "^1.2 || ^2",
-                "wp-cli/extension-command": "^1.1 || ^2",
-                "wp-cli/package-command": "^1 || ^2",
-                "wp-cli/wp-cli-tests": "^2.1"
-            },
-            "suggest": {
-                "ext-readline": "Include for a better --prompt implementation",
-                "ext-zip": "Needed to support extraction of ZIP archives when doing downloads or updates"
-            },
-            "bin": [
-                "bin/wp",
-                "bin/wp.bat"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.4.x-dev"
-                },
-                "patches": {
-                    "mustache/mustache": {
-                        "Avoid notices on PHP 7.4+": "https://patch-diff.githubusercontent.com/raw/bobthecow/mustache.php/pull/349.patch"
-                    }
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "WP_CLI": "php"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "WP-CLI framework",
-            "homepage": "https://wp-cli.org",
-            "keywords": [
-                "cli",
-                "wordpress"
-            ],
-            "time": "2019-11-12T15:26:05+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/includes/Exceptions/QueryException.php
+++ b/includes/Exceptions/QueryException.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Query exceptions are thrown when errors occur while querying the database.
+ *
+ * @package WooCommerce_Custom_Orders_Table
+ * @author  Liquid Web
+ */
+
+namespace LiquidWeb\WooCommerceCustomOrdersTable\Exceptions;
+
+/**
+ * Exception that indicates issues during data migration.
+ */
+class QueryException extends \Exception {
+
+}

--- a/includes/Util/QueryIterator.php
+++ b/includes/Util/QueryIterator.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * Iterator for looping through a posts query.
+ *
+ * This is strongly based on \WP_CLI\Iterators\Query, but is bundled with the plugin since WP-CLI
+ * may not always be available on WooCommerce sites.
+ *
+ * @link https://github.com/wp-cli/wp-cli/blob/master/php/WP_CLI/Iterators/Query.php
+ *
+ * @package WooCommerce_Custom_Orders_Table
+ * @author  Liquid Web
+ */
+
+namespace LiquidWeb\WooCommerceCustomOrdersTable\Util;
+
+use LiquidWeb\WooCommerceCustomOrdersTable\Exceptions\QueryException;
+
+/**
+ * Iterate through a database query results.
+ */
+class QueryIterator implements \Countable, \Iterator {
+
+	/**
+	 * The maximum number of rows to retrieve at a time.
+	 *
+	 * @var int
+	 */
+	private $chunk_size;
+
+	/**
+	 * The modified query, used for counting rows.
+	 *
+	 * @var string
+	 */
+	private $count_query = '';
+
+	/**
+	 * The global $wpdb instance.
+	 *
+	 * @var \WPDB
+	 */
+	private $db;
+
+	/**
+	 * Whether or not we've made it through all available data.
+	 *
+	 * @var bool
+	 */
+	private $depleted = false;
+
+	/**
+	 * Our current position against all available data.
+	 *
+	 * @var int
+	 */
+	private $global_index = 0;
+
+	/**
+	 * Our current position within the current dataset.
+	 *
+	 * @var int
+	 */
+	private $index_in_results = 0;
+
+	/**
+	 * The current offset to use when loading the next set of data.
+	 *
+	 * @var int
+	 */
+	private $offset = 0;
+
+	/**
+	 * The raw, user-provided SQL query.
+	 *
+	 * @var string
+	 */
+	private $query = '';
+
+	/**
+	 * The current set of data from the database.
+	 *
+	 * @var array
+	 */
+	private $results = [];
+
+	/**
+	 * How many total rows are we aware of?
+	 *
+	 * @var int
+	 */
+	private $row_count = 0;
+
+	/**
+	 * Creates a new query iterator.
+	 *
+	 * @param string $query      The query as a string. It shouldn't include any LIMIT clauses.
+	 * @param int    $chunk_size Optional. How many rows to retrieve at once; default is 500.
+	 */
+	public function __construct( $query, $chunk_size = 500 ) {
+		$this->query      = $query;
+		$this->chunk_size = $chunk_size;
+		$this->db         = $GLOBALS['wpdb'];
+
+		// Swap the SELECT clause for SELECT COUNT(*).
+		$this->count_query = preg_replace( '/^.*? FROM /', 'SELECT COUNT(*) FROM ', $query, 1, $replacements );
+
+		// If we haven't found anything, assume we can't count.
+		if ( 1 !== $replacements ) {
+			$this->count_query = '';
+		}
+	}
+
+	/**
+	 * Count the total number of query results.
+	 *
+	 * @return int
+	 */
+	public function count() {
+		$this->row_count = (int) $this->db->get_var( $this->count_query );
+
+		return $this->row_count;
+	}
+
+	/**
+	 * Get the current element.
+	 *
+	 * @return object An object representing the current row.
+	 */
+	public function current() {
+		return $this->results[ $this->index_in_results ];
+	}
+
+	/**
+	 * Get the current element's key.
+	 *
+	 * @return int
+	 */
+	public function key() {
+		return $this->global_index;
+	}
+
+	/**
+	 * Advance the iterator.
+	 */
+	public function next() {
+		$this->index_in_results++;
+		$this->global_index++;
+	}
+
+	/**
+	 * Reset everything.
+	 */
+	public function rewind() {
+		$this->results          = [];
+		$this->global_index     = 0;
+		$this->index_in_results = 0;
+		$this->offset           = 0;
+		$this->depleted         = false;
+	}
+
+	/**
+	 * Check if the current position is valid.
+	 *
+	 * If no query data has yet been loaded (or we've already looped through it), the next set of
+	 * results will be loaded from the database.
+	 *
+	 * @return bool
+	 */
+	public function valid() {
+		if ( $this->depleted ) {
+			return false;
+		}
+
+		// If we don't yet have the data, query the database.
+		if ( ! isset( $this->results[ $this->index_in_results ] ) ) {
+			$items_loaded = $this->load_items_from_db();
+
+			// Nothing came back, so we've reached the end.
+			if ( ! $items_loaded ) {
+				$this->rewind();
+				$this->depleted = true;
+				return false;
+			}
+
+			$this->index_in_results = 0;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Reduces the offset when the query row count shrinks
+	 *
+	 * In cases where the iterated rows are being updated such that they will no
+	 * longer be returned by the original query, the offset must be reduced to
+	 * iterate over all remaining rows.
+	 */
+	private function adjust_offset_for_shrinking_result_set() {
+		if ( empty( $this->count_query ) ) {
+			return;
+		}
+
+		$row_count = $this->db->get_var( $this->count_query );
+
+		// We have fewer rows than the last time we counted.
+		if ( $row_count < $this->row_count ) {
+			$this->offset -= $this->row_count - $row_count;
+		}
+
+		$this->row_count = $row_count;
+	}
+
+	/**
+	 * Retrieve the next chunk of results from the database.
+	 *
+	 * @throws QueryException When a database error is encountered.
+	 *
+	 * @return bool True if results were loaded, false otherwise.
+	 */
+	private function load_items_from_db() {
+		$this->adjust_offset_for_shrinking_result_set();
+
+		$this->results = $this->db->get_results(
+			$this->query . sprintf( ' LIMIT %d OFFSET %d', $this->chunk_size, $this->offset ),
+			OBJECT
+		);
+
+		if ( ! $this->results ) {
+			if ( $this->db->last_error ) {
+				throw new QueryException( 'Database error: ' . $this->db->last_error );
+			}
+
+			return false;
+		}
+
+		$this->offset += $this->chunk_size;
+		return true;
+	}
+}

--- a/includes/class-woocommerce-custom-orders-table-cli.php
+++ b/includes/class-woocommerce-custom-orders-table-cli.php
@@ -6,7 +6,7 @@
  * @author  Liquid Web
  */
 
-use WP_CLI\Iterators\Query as QueryIterator;
+use LiquidWeb\WooCommerceCustomOrdersTable\Util\QueryIterator;
 
 /**
  * Manages the contents of the WooCommerce orders table.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,12 +2,18 @@
 <ruleset name="WordPress Coding Standards for Plugins">
 	<description>Generally-applicable sniffs for WordPress plugins</description>
 
-	<!-- The plugin should be compatible with PHP 5.2 and newer. -->
-	<config name="testVersion" value="5.2-"/>
+	<!-- WooCommerce requires PHP 5.6 or newer. -->
+	<config name="testVersion" value="5.6-"/>
 
 	<rule ref="WooCommerce-Core">
 		<!-- Let the plugin files have @author tags. -->
 		<exclude name="Core.Commenting.CommentTags.AuthorTag" />
+
+		<!-- WooCommerce packages use PSR-4 autoloading, so don't worry about WP conventions. -->
+		<exclude name="WordPress.Files.FileName" />
+
+		<!-- Permit short-array syntax. -->
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
 	</rule>
 
 	<rule ref="WordPress.WP.I18n">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,7 @@
 		<!-- Plugin-specific tests. -->
 		<testsuite name="plugin">
 			<directory prefix="test-" suffix=".php">./tests/</directory>
+			<directory suffix="Test.php">./tests/</directory>
 			<exclude>tests/test-sample.php</exclude>
 		</testsuite>
 

--- a/tests/Util/QueryIteratorTest.php
+++ b/tests/Util/QueryIteratorTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Tests for the Migration utility.
+ *
+ * @package WooCommerce_Custom_Orders_Table
+ * @author  Liquid Web
+ */
+
+namespace Tests\Util;
+
+use LiquidWeb\WooCommerceCustomOrdersTable\Util\QueryIterator;
+use LiquidWeb\WooCommerceCustomOrdersTable\Exceptions\QueryException;
+use TestCase;
+
+/**
+ * @covers LiquidWeb\WooCommerceCustomOrdersTable\Util\QueryIterator
+ * @group Util
+ */
+class QueryIteratorTest extends TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_iterate_through_results() {
+		global $wpdb;
+
+		$post_ids = $this->factory->post->create_many( 3 );
+		$results  = [];
+
+		$query = new QueryIterator( "SELECT * FROM {$wpdb->posts}" );
+
+		while ( $query->valid() ) {
+			$results[] = (int) $query->current()->ID;
+
+			$query->next();
+		}
+
+		$this->assertSame( $post_ids, $results );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_be_able_to_batch_results() {
+		global $wpdb;
+
+		$post_ids = $this->factory->post->create_many( 3 );
+		$results  = [];
+		$keys     = [];
+
+		$query = new QueryIterator( "SELECT * FROM {$wpdb->posts}", 2 );
+
+		while ( $query->valid() ) {
+			$results[] = (int) $query->current()->ID;
+			$keys[]    = $query->key();
+
+			$query->next();
+		}
+
+		$this->assertSame( $post_ids, $results );
+		$this->assertContains(
+			'LIMIT 2 OFFSET 4',
+			$wpdb->last_query,
+			'The last query should have been empty, but included offsets for the previous two queries.'
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_implement_the_Countable_interface() {
+		global $wpdb;
+
+		$this->factory->post->create_many( 3 );
+
+		$query = new QueryIterator( "SELECT * FROM {$wpdb->posts}" );
+
+		$this->assertSame( 3, $query->count() );
+	}
+
+	/**
+	 * @test
+	 * @depends it_should_implement_the_Countable_interface
+	 */
+	public function the_count_should_be_unaffected_by_batching() {
+		global $wpdb;
+
+		$this->factory->post->create_many( 3 );
+
+		$query = new QueryIterator( "SELECT * FROM {$wpdb->posts}", 1 );
+
+		$this->assertSame( 3, $query->count() );
+	}
+}

--- a/woocommerce-custom-orders-table.php
+++ b/woocommerce-custom-orders-table.php
@@ -33,13 +33,20 @@ define( 'WC_CUSTOM_ORDER_TABLE_PATH', plugin_dir_path( __FILE__ ) );
  * @return void
  */
 function wc_custom_order_table_autoload( $class ) {
-	// Bail early if the class/trait/interface is not in the root namespace.
-	if ( strpos( $class, '\\' ) !== false ) {
-		return;
+
+	/**
+	 * Eventually, we'll be moving towards a proper, PSR-4 autoloading scheme.
+	 *
+	 * @link https://github.com/woocommerce/woocommerce-example-package
+	 * @link https://github.com/liquidweb/woocommerce-custom-orders-table/issues/153
+	 */
+	if ( strpos( $class, '\\' ) === false ) {
+		$filename = strtolower( 'class-' . str_replace( '_', '-', $class ) . '.php' );
+	} else {
+		$class    = str_replace( 'LiquidWeb\\WooCommerceCustomOrdersTable\\', '', $class );
+		$filename = str_replace( '\\', '/', $class ) . '.php';
 	}
 
-	// Assemble file path and name according to WordPress code style.
-	$filename = strtolower( 'class-' . str_replace( '_', '-', $class ) . '.php' );
 	$filepath = WC_CUSTOM_ORDER_TABLE_PATH . 'includes/' . $filename;
 
 	// Bail if the file name we generated does not exist.


### PR DESCRIPTION
This PR defines a new `QueryIterator` class, which is based on the `WP_CLI\Iterators\Query` class. Our iterator also extends the original, adding support for the `Countable` interface, along with better inline documentation and tests.

There are a few reasons for importing this into the project:

1. Leverage iterators rather than ad-hoc `while()` loops, with automatic support for adjusting offsets and creating corresponding `COUNT(*)` queries
2. Ensure that we have the iterator available regardless of whether or not WP-CLI is present on the target system. This will be important when it comes to #66

This PR duplicates some code from #159, and should be considered a blocker for that PR. It also is the first use of PSR-4 autoloading in the repository, which will eventually be the norm (see #161).