### PR TITLE
Only add the filters for WC_Customer_Data_Store_Custom_Table once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Add a `method_exists()` check to the wildcard `set_{$column}` method ([#139], props @blohbaugh).
 * Rewrite the way that WooCommerce core is installed in test environments ([#154]).
 * Use offsets to avoid infinite loops during migration ([#157], props @mfs-mindsize).
+* Only register the hooks for `WC_Customer_Data_Store_Custom_Table` once ([#164]).
 
 ## [Version 1.0.0 (Release Candidate 3)] - 2019-07-24
 
@@ -131,3 +132,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [#124]: https://github.com/liquidweb/woocommerce-custom-orders-table/pull/124
 [#126]: https://github.com/liquidweb/woocommerce-custom-orders-table/pull/126
 [#127]: https://github.com/liquidweb/woocommerce-custom-orders-table/pull/127
+[#138]: https://github.com/liquidweb/woocommerce-custom-orders-table/pull/138
+[#139]: https://github.com/liquidweb/woocommerce-custom-orders-table/pull/139
+[#152]: https://github.com/liquidweb/woocommerce-custom-orders-table/pull/152
+[#154]: https://github.com/liquidweb/woocommerce-custom-orders-table/pull/154
+[#157]: https://github.com/liquidweb/woocommerce-custom-orders-table/pull/157
+[#164]: https://github.com/liquidweb/woocommerce-custom-orders-table/pull/164

--- a/includes/class-wc-customer-data-store-custom-table.php
+++ b/includes/class-wc-customer-data-store-custom-table.php
@@ -13,17 +13,6 @@
 class WC_Customer_Data_Store_Custom_Table extends WC_Customer_Data_Store {
 
 	/**
-	 * Register callbacks when the data store is first instantiated.
-	 */
-	public function __construct() {
-		add_filter( 'woocommerce_pre_customer_bought_product', __CLASS__ . '::pre_customer_bought_product', 10, 4 );
-
-		// Handle deleting a customer from the database.
-		add_action( 'deleted_user', __CLASS__ . '::reset_order_customer_id_on_deleted_user' );
-		remove_action( 'deleted_user', 'wc_reset_order_customer_id_on_deleted_user' );
-	}
-
-	/**
 	 * Gets the customers last order.
 	 *
 	 * @global $wpdb
@@ -137,6 +126,17 @@ class WC_Customer_Data_Store_Custom_Table extends WC_Customer_Data_Store {
 		}
 
 		return $spent;
+	}
+
+	/**
+	 * Register callbacks when the data store is first instantiated.
+	 */
+	public static function add_hooks() {
+		add_filter( 'woocommerce_pre_customer_bought_product', __CLASS__ . '::pre_customer_bought_product', 10, 4 );
+
+		// Handle deleting a customer from the database.
+		add_action( 'deleted_user', __CLASS__ . '::reset_order_customer_id_on_deleted_user' );
+		remove_action( 'deleted_user', 'wc_reset_order_customer_id_on_deleted_user' );
 	}
 
 	/**

--- a/includes/class-woocommerce-custom-orders-table.php
+++ b/includes/class-woocommerce-custom-orders-table.php
@@ -42,6 +42,8 @@ class WooCommerce_Custom_Orders_Table {
 		// When associating previous orders with a customer based on email, update the record.
 		add_action( 'woocommerce_update_new_customer_past_order', 'WooCommerce_Custom_Orders_Table_Filters::update_past_customer_order', 10, 2 );
 
+		WC_Customer_Data_Store_Custom_Table::add_hooks();
+
 		// Register the table within WooCommerce.
 		add_filter( 'woocommerce_install_get_tables', array( $this, 'register_table_name' ) );
 


### PR DESCRIPTION
Instead of adding the hooks in the constructor (potentially causing a *ton* of hooked callbacks), register the customer data store hooks once.