### PR TITLE
Bump WooCommerce requirements now that 4.0 is available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,12 @@ php:
 # - WordPress: latest -1
 # - WooCommerce: latest -2
 env:
+  - WP_VERSION=5.3 WC_VERSION=4.0
   - WP_VERSION=5.3 WC_VERSION=3.9
   - WP_VERSION=5.3 WC_VERSION=3.8
-  - WP_VERSION=5.3 WC_VERSION=3.7
+  - WP_VERSION=5.2 WC_VERSION=4.0
   - WP_VERSION=5.2 WC_VERSION=3.9
   - WP_VERSION=5.2 WC_VERSION=3.8
-  - WP_VERSION=5.2 WC_VERSION=3.7
 
 matrix:
   fast_finish: true
@@ -41,11 +41,11 @@ matrix:
       env: WP_VERSION=trunk WC_VERSION=latest
   exclude:
     - php: 7.4
+      env: WP_VERSION=5.2 WC_VERSION=4.0
+    - php: 7.4
       env: WP_VERSION=5.2 WC_VERSION=3.9
     - php: 7.4
       env: WP_VERSION=5.2 WC_VERSION=3.8
-    - php: 7.4
-      env: WP_VERSION=5.2 WC_VERSION=3.7
   allow_failures:
     - name: Code Coverage
     - name: Bleeding Edge

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -33,6 +33,9 @@
 				than using the %WC_VERSION% placeholder.
 			-->
 
+			<!-- @link https://github.com/woocommerce/woocommerce/pull/25883 -->
+			<exclude>./vendor/woocommerce/woocommerce-src-4.0/tests/unit-tests/util/install.php</exclude>
+
 			<!-- @link https://github.com/woocommerce/woocommerce/pull/25403 -->
 			<exclude>./vendor/woocommerce/woocommerce-src-3.8/tests/unit-tests/util/api-functions.php</exclude>
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -35,11 +35,9 @@
 
 			<!-- @link https://github.com/woocommerce/woocommerce/pull/25403 -->
 			<exclude>./vendor/woocommerce/woocommerce-src-3.8/tests/unit-tests/util/api-functions.php</exclude>
-			<exclude>./vendor/woocommerce/woocommerce-src-3.7/tests/unit-tests/util/api-functions.php</exclude>
 
 			<!-- @link https://github.com/woocommerce/woocommerce/pull/25378 -->
 			<exclude>./vendor/woocommerce/woocommerce-src-3.8/tests/unit-tests/geolocation/class-wc-tests-geolite-integration.php</exclude>
-			<exclude>./vendor/woocommerce/woocommerce-src-3.7/tests/unit-tests/geolocation/class-wc-tests-geolite-integration.php</exclude>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/woocommerce-custom-orders-table.php
+++ b/woocommerce-custom-orders-table.php
@@ -9,8 +9,8 @@
  * License:              GPLv3 or later
  * License URI:          https://www.gnu.org/licenses/gpl-3.0.html
  *
- * WC requires at least: 3.7.1
- * WC tested up to:      4.0.0-beta.1
+ * WC requires at least: 3.8.0
+ * WC tested up to:      4.0.0
  *
  * @package WooCommerce_Custom_Orders_Table
  * @author  Liquid Web


### PR DESCRIPTION
[Per our Compatibility Policy](https://github.com/liquidweb/woocommerce-custom-orders-table/blob/develop/CONTRIBUTING.md#compatibility-policy), we support the latest two releases of WordPress and latest 3 releases of WooCommerce. WooCommerce 4.0 is now available, which means our currently-supported WooCommerce releases are:

- 4.0
- 3.9
- 3.8