### PR TITLE
WIP PoC for the removal when wp_delete_post is used.

### DIFF
--- a/includes/class-woocommerce-custom-orders-table-filters.php
+++ b/includes/class-woocommerce-custom-orders-table-filters.php
@@ -271,4 +271,19 @@ class WooCommerce_Custom_Orders_Table_Filters {
 		$order->set_customer_id( $customer->ID );
 		$order->save();
 	}
+
+	public static function delete_order( $order_id ) {
+		global $wpdb;
+
+		if ( in_array( get_post_type( $order_id ), wc_get_order_types(), true ) ) {
+			// Not re-useing the code of 'delete' function of data store because it calls the parent function.
+			$wpdb->delete(
+					wc_custom_order_table()->get_table_name(),
+					array(
+						'order_id' => $order_id,
+						)
+					);
+		}
+	}
+
 }

--- a/includes/class-woocommerce-custom-orders-table.php
+++ b/includes/class-woocommerce-custom-orders-table.php
@@ -42,6 +42,9 @@ class WooCommerce_Custom_Orders_Table {
 		// When associating previous orders with a customer based on email, update the record.
 		add_action( 'woocommerce_update_new_customer_past_order', 'WooCommerce_Custom_Orders_Table_Filters::update_past_customer_order', 10, 2 );
 
+		// When deleting orders as post type (p.e. bulk actions) we should hook to delete it form the custom table.
+		add_action( 'before_delete_post', 'WooCommerce_Custom_Orders_Table_Filters::delete_order' );
+
 		WC_Customer_Data_Store_Custom_Table::add_hooks();
 
 		// Register the table within WooCommerce.


### PR DESCRIPTION
This PR fixes https://github.com/liquidweb/woocommerce-custom-orders-table/issues/111

## Description of the problem.
Operations like bulk operations delete with a [direct URL](https://developer.wordpress.org/reference/functions/get_delete_post_link/) or maybe others can directly use `wp_delete_post` function. In these cases, the order is properly deleted from the `posts` table but not of the `woocommerce_orders` one because no data-store is being used in the whole operation.

## How does it work in WooCommerce
WooCommerce manage the extra 'order' data in the `before_delete_post` filter, see: 
https://github.com/woocommerce/woocommerce/blob/master/includes/class-wc-post-data.php#L388

## Proposed solution
Register the `delete_post` filter to perform the delete operation in the custom table.

This has an open question, is that when the data-store is used it calls the parent delete, can it create a loop? I don't test it, with the PR we are going to see the tests which are testing so. Also, maybe then the datastore can just delete the post and let the filter act to clear the custom table, but I don't want to modify also this without feedback.